### PR TITLE
Add pull request template for linked issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+- Describe the change clearly and briefly.
+
+## Linked Issue
+
+Closes #
+
+## Testing
+
+- Describe the checks you ran.
+- Include any manual verification notes.
+
+## Notes
+
+- Add rollout notes, assumptions, or follow-up items if needed.


### PR DESCRIPTION
## Summary

- add a default pull request template
- prompt contributors to use GitHub closing keywords for linked issues
- include simple testing and notes sections for consistent PRs

## Linked Issue

Refs #21

## Testing

- not run; documentation/template-only change

## Notes

- this template is intended to encourage issue linking and auto-close behavior on merge to main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that affects contributor workflow but not runtime behavior.
> 
> **Overview**
> Adds a default `.github/pull_request_template.md` to standardize PR descriptions with sections for **Summary**, **Linked Issue** (using `Closes #`), **Testing**, and **Notes** to encourage consistent issue linking and verification details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a19396fdb3dffb46323b1d2856969dfcdf3e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->