### PR TITLE
Refine issue-driven branch and PR workflow policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,9 @@
 
 ## Linked Issue
 
-Closes #
+- Use `Closes #...` if this PR fully completes the issue.
+- Use `Refs #...` if this PR is related but does not complete the issue.
+- Example: `Closes #21`
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,17 @@
 
 ## Branch And Git Workflow
 
+- New implementation work should start from a GitHub issue. If a task does not already have an issue, create one before coding begins.
+- Before starting a new task branch, update local `main` from the latest remote `main`.
 - Never implement work directly on `main`.
 - Always create or switch to a task-specific branch before making code changes.
 - Prefer branch names like `feature/issue-9-stripe-checkout`, `fix/issue-14-email-confirmation`, or `chore/ci-setup`.
 - Open a pull request for every change set instead of pushing directly to `main`.
+- Pull requests should link the related issue. Use a closing keyword such as `Closes #21` when the issue is fully completed by the PR, and use `Refs #21` when it is only related work.
 - Treat merges to `main` as the trigger point for production-oriented builds and releases.
 - Keep history linear. Prefer squash merges or rebase-based merges, and avoid merge commits that create non-linear history.
 - Before opening or updating a pull request, rebase onto the latest `main` when needed rather than merging `main` into the feature branch.
+- After a pull request is merged, delete the head branch.
 - Local commits to `main` are blocked by the repo hook and should be treated as a workflow violation.
 
 ## Secrets And Environment Variable Rules

--- a/README.md
+++ b/README.md
@@ -51,10 +51,14 @@ npm run dev
 
 ## Development Workflow
 
+- Start new implementation work from a GitHub issue. If no issue exists yet, create one before coding.
+- Update local `main` from the latest remote `main` before creating a new task branch.
 - Treat `main` as a protected branch.
 - Create a new branch for each issue or focused unit of work.
 - Open a pull request for changes instead of committing directly to `main`.
+- Link the related issue in the pull request. Use `Closes #...` when the PR fully completes the issue, or `Refs #...` when it does not.
 - Keep commit history linear by preferring squash merges or rebase-based merges.
+- Delete feature branches after merge.
 - Use merges to `main` as the trigger for production-oriented build and deploy workflows.
 
 ## Environment Variable Guidance


### PR DESCRIPTION
## Summary

- require issue-first workflow before new implementation work begins
- require updating local main before branching for new work
- document linked-issue and branch-deletion expectations more explicitly
- clarify PR template guidance for Closes #... versus Refs #...

## Linked Issue

Closes #21

## Testing

- not run; documentation and PR template changes only

## Notes

- GitHub branch protection and automatic branch deletion still need to be enabled in repository settings to fully enforce the hosted-side behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to workflow guidance; no runtime or infrastructure changes.
> 
> **Overview**
> Clarifies the repo’s issue-driven workflow expectations across docs: new work should start from a GitHub issue, local `main` should be updated before branching, PRs should link issues using `Closes` vs `Refs`, and merged branches should be deleted.
> 
> Updates the PR template and reinforces the same guidance in `AGENTS.md` and `README.md` for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fb288285b79c2157cccc5eec33ae237fec534e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->