### PR TITLE
Set up shared layout, metadata, and site shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,8 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { SiteFooter } from "@/components/site-footer";
+import { SiteHeader } from "@/components/site-header";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,8 +15,13 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Bubelpalooza",
-  description: "Public event site for Bubelpalooza.",
+  metadataBase: new URL("https://bubelpalooza.com"),
+  title: {
+    default: "Bubelpalooza",
+    template: "%s | Bubelpalooza",
+  },
+  description:
+    "Public event site for Bubelpalooza, a crawfish boil and pool party with a mini music showcase.",
 };
 
 export default function RootLayout({
@@ -27,7 +34,13 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full bg-[linear-gradient(180deg,#fff7ed_0%,#fffdf8_28%,#ffffff_100%)] text-slate-950">
+        <div className="flex min-h-screen flex-col">
+          <SiteHeader />
+          <main className="flex-1">{children}</main>
+          <SiteFooter />
+        </div>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,38 +1,38 @@
 export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,#fff5e8,white_45%)] px-6 py-24 text-slate-950">
-      <div className="w-full max-w-3xl rounded-3xl border border-black/5 bg-white/90 p-10 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur sm:p-14">
+    <section className="px-6 py-20 sm:py-24">
+      <div className="mx-auto w-full max-w-5xl rounded-[2rem] border border-black/5 bg-white/90 p-10 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur sm:p-14">
         <p className="text-sm font-semibold uppercase tracking-[0.28em] text-orange-700">
           Bubelpalooza
         </p>
         <h1 className="mt-4 text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
-          Next.js foundation is in place.
+          The shared site shell is ready for the event experience.
         </h1>
         <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-600">
-          The App Router, TypeScript, Tailwind CSS, and ESLint baseline are now
-          wired up and ready for the event site buildout.
+          The app now has a reusable header, footer, and baseline metadata layer
+          to support the public event site as it grows.
         </p>
-        <div className="mt-10 grid gap-4 sm:grid-cols-2">
-          <div className="rounded-2xl border border-orange-100 bg-orange-50 p-5">
+        <div className="mt-10 grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+          <div className="rounded-2xl border border-orange-100 bg-orange-50 p-6">
             <h2 className="text-base font-semibold text-slate-900">
-              Foundation ready
+              Shared layout in place
             </h2>
             <p className="mt-2 text-sm leading-6 text-slate-600">
-              Use this app as the starting point for the public event
-              experience, ticketing flow, and future merchandise work.
+              Future pages can now plug into a consistent shell instead of
+              re-creating top-level structure one route at a time.
             </p>
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
             <h2 className="text-base font-semibold text-slate-900">
               Next suggested step
             </h2>
             <p className="mt-2 text-sm leading-6 text-slate-600">
-              Build the shared layout and metadata layer before adding the real
-              homepage and supporting event pages.
+              Build the real homepage and supporting event-information pages on
+              top of this shell.
             </p>
           </div>
         </div>
       </div>
-    </main>
+    </section>
   );
 }

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,0 +1,10 @@
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-black/5 bg-white/70">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-6 py-8 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
+        <p>Bubelpalooza is being built as a public home for event info, tickets, and merchandise.</p>
+        <p className="text-slate-500">Family boil and pool party first. Music showcase second.</p>
+      </div>
+    </footer>
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -3,7 +3,7 @@ export function SiteFooter() {
     <footer className="border-t border-black/5 bg-white/70">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-6 py-8 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
         <p>Bubelpalooza is being built as a public home for event info, tickets, and merchandise.</p>
-        <p className="text-slate-500">Family boil and pool party first. Music showcase second.</p>
+        <p className="text-slate-500">A full day of crawfish, poolside fun, and live music.</p>
       </div>
     </footer>
   );

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,0 +1,19 @@
+export function SiteHeader() {
+  return (
+    <header className="border-b border-black/5 bg-white/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-5">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-orange-700">
+            Bubelpalooza
+          </p>
+          <p className="mt-2 text-sm text-slate-600">
+            Crawfish boil, pool party, and mini music showcase
+          </p>
+        </div>
+        <div className="hidden text-sm font-medium text-slate-500 sm:block">
+          Public event site in progress
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

- add reusable site header and footer components
- wrap the app in a shared top-level shell from pp/layout.tsx
- improve baseline metadata for Bubelpalooza
- update the homepage to render inside the shared shell

## Linked Issue

Closes #2

## Testing

- 
pm run lint
- 
pm run build
- 
pm run dev smoke test on http://127.0.0.1:3000

## Notes

- the shell stays intentionally simple so later issues can add the real homepage and navigation structure without reworking the app root
