### PR TITLE
Build the first public homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,69 +9,188 @@ import {
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
 
 export default function Home() {
   return (
-    <section className="px-6 py-20 sm:py-24">
-      <div className="mx-auto w-full max-w-5xl rounded-[2rem] border border-black/5 bg-white/90 p-10 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur sm:p-14">
-        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-orange-700">
-          Bubelpalooza
-        </p>
-        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
-          The component foundation is ready for the event experience.
-        </h1>
-        <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-600">
-          The app now has shared UI primitives in place so the public event site
-          can grow with less visual churn and less component rework.
-        </p>
-        <div className="mt-8 flex flex-wrap gap-3">
-          <Button>Tickets coming soon</Button>
-          <Button variant="outline">Merch preview next</Button>
-        </div>
-        <div className="mt-10 grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
-          <Card className="border-orange-100 bg-orange-50/70">
+    <div className="px-6 py-12 sm:py-16">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <section className="overflow-hidden rounded-[2rem] border border-black/5 bg-[linear-gradient(135deg,#fff1df_0%,#fff8f0_45%,#fff_100%)] shadow-[0_28px_90px_rgba(15,23,42,0.08)]">
+          <div className="grid gap-10 px-8 py-10 sm:px-12 sm:py-14 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.32em] text-orange-700">
+                Bubelpalooza
+              </p>
+              <h1 className="mt-5 max-w-3xl text-5xl font-semibold tracking-tight text-balance text-slate-950 sm:text-6xl">
+                A crawfish boil and pool party with live music built into the day.
+              </h1>
+              <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-600">
+                Come hungry, stay all afternoon, and settle into a relaxed day
+                of great food, cold drinks, sunshine, and a mini showcase that
+                keeps the energy up without stealing the spotlight.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-3">
+                <Button asChild size="lg">
+                  <a href="#tickets">See ticket plans</a>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <a href="#merch">Explore merch</a>
+                </Button>
+              </div>
+            </div>
+            <Card className="border-white/70 bg-white/85">
+              <CardHeader>
+                <CardTitle>What to expect</CardTitle>
+                <CardDescription>
+                  Bubelpalooza is designed to feel easygoing, festive, and
+                  worth making a day of.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 text-sm text-slate-600">
+                <div>
+                  <p className="font-medium text-slate-900">Boil at the center</p>
+                  <p className="mt-1">Crawfish, shared plates, and the kind of food that gets everyone gathering around the table.</p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-900">Poolside energy</p>
+                  <p className="mt-1">A casual summer-party atmosphere with room to relax, cool off, and spend time with friends and family.</p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-900">Music in the mix</p>
+                  <p className="mt-1">A compact live showcase that adds rhythm and personality to the day without turning the event into a concert-first experience.</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          <Card className="bg-white/90">
             <CardHeader>
-              <CardTitle>Shared layout in place</CardTitle>
+              <CardTitle>Food-first gathering</CardTitle>
               <CardDescription>
-                Future pages can now plug into a consistent shell and component
-                set instead of re-creating UI patterns route by route.
+                Built around the crawfish boil and the kind of hospitality that
+                makes guests want to linger.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+          <Card className="bg-white/90">
+            <CardHeader>
+              <CardTitle>Pool-party mood</CardTitle>
+              <CardDescription>
+                Light, social, and summer-driven rather than formal or overly
+                scheduled.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+          <Card className="bg-white/90">
+            <CardHeader>
+              <CardTitle>Live music touches</CardTitle>
+              <CardDescription>
+                A mini showcase that rounds out the atmosphere and gives the day
+                a little extra spark.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <Card id="tickets" className="border-orange-100 bg-orange-50/75">
+            <CardHeader>
+              <CardTitle>Tickets will be the easiest way in</CardTitle>
+              <CardDescription>
+                The site is being prepared for a simple checkout flow with clear
+                options, quick confirmation, and a smooth path to event-day info.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm leading-6 text-slate-600">
+              <p>
+                Expect clear admission options, quick purchase steps, and
+                follow-up details that help guests feel ready before they
+                arrive.
+              </p>
+            </CardContent>
+            <CardFooter>
+              <Button>Ticket options coming soon</Button>
+            </CardFooter>
+          </Card>
+
+          <Card id="merch" className="bg-slate-50/90">
+            <CardHeader>
+              <CardTitle>Merch is part of the experience</CardTitle>
+              <CardDescription>
+                Event shirts and related items will live alongside ticketing so
+                the site feels like one cohesive event home.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm leading-6 text-slate-600">
+              <p>
+                The first version will keep merchandise straightforward and
+                easy to browse, with room to expand as the event brand grows.
+              </p>
+            </CardContent>
+            <CardFooter>
+              <Button variant="outline">Merch preview coming soon</Button>
+            </CardFooter>
+          </Card>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+          <Card className="bg-white/90">
+            <CardHeader>
+              <CardTitle>Why people will want to come</CardTitle>
+              <CardDescription>
+                The goal is a day that feels welcoming, memorable, and easy to
+                say yes to.
               </CardDescription>
             </CardHeader>
             <CardContent>
               <Accordion type="single" collapsible>
-                <AccordionItem value="foundation">
-                  <AccordionTrigger>What is already set up?</AccordionTrigger>
+                <AccordionItem value="food">
+                  <AccordionTrigger>It feels like a real gathering</AccordionTrigger>
                   <AccordionContent>
-                    The app has a reusable header, footer, baseline metadata,
-                    and the first `shadcn/ui` primitives needed for upcoming
-                    homepage and FAQ work.
+                    Bubelpalooza should feel social and lived-in, not like a
+                    transactional event page with a ticket button bolted onto it.
                   </AccordionContent>
                 </AccordionItem>
-                <AccordionItem value="next">
-                  <AccordionTrigger>Why add components this early?</AccordionTrigger>
+                <AccordionItem value="pace">
+                  <AccordionTrigger>The day has a natural flow</AccordionTrigger>
                   <AccordionContent>
-                    Establishing the design primitives now helps keep later page
-                    work consistent and reduces UI cleanup once ticketing and
-                    event information pages expand.
+                    Guests can picture the rhythm immediately: arrive, eat,
+                    hang out, cool off, enjoy the atmosphere, and stay awhile.
+                  </AccordionContent>
+                </AccordionItem>
+                <AccordionItem value="music">
+                  <AccordionTrigger>Music adds texture, not confusion</AccordionTrigger>
+                  <AccordionContent>
+                    The showcase supports the identity of the event rather than
+                    changing the pitch into something that feels like a different product.
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>
             </CardContent>
           </Card>
-          <Card className="bg-slate-50/90">
-            <CardHeader>
-              <CardTitle>Next suggested step</CardTitle>
-              <CardDescription>
-                Build the real homepage and supporting event-information pages
-                on top of this shared shell and component baseline.
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </div>
+
+          <section className="rounded-[2rem] border border-black/5 bg-[linear-gradient(180deg,#fff_0%,#f8fafc_100%)] px-8 py-10 shadow-[0_24px_80px_rgba(15,23,42,0.05)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+              Event Summary
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-tight text-balance text-slate-950">
+              A relaxed, flavor-forward summer event with its own personality.
+            </h2>
+            <p className="mt-5 max-w-2xl text-base leading-7 text-slate-600">
+              The site should help guests understand the tone right away:
+              Bubelpalooza is about the boil, the pool, the people, and the
+              laid-back energy that makes the day feel special. The music is
+              part of the draw, but the full experience is what makes it worth
+              attending.
+            </p>
+          </section>
+        </section>
       </div>
-    </section>
+    </div>
   );
 }

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -17,7 +17,7 @@ export function SiteHeader() {
           size="sm"
           className="hidden bg-white/80 sm:inline-flex"
         >
-          Event site in progress
+          Summer gathering
         </Button>
       </div>
     </header>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- replace the internal placeholder page with a real guest-facing homepage
- add a clear hero, event summary, and visible ticket and merch calls to action
- position the crawfish boil and pool party as the center of the experience while keeping live music present as part of the day
- refine the header copy so the shell feels more public-facing

## Linked Issue

Closes #3

## Testing

- 
pm run lint
- 
pm run build
- 
pm run dev smoke test on http://127.0.0.1:3000

## Notes

- homepage copy stays placeholder-safe and directional without introducing real event operations data yet
- 
ext-env.d.ts updated with the current Next-generated route types reference during verification
