### PR TITLE
Prepare Vercel deployment and environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ DATABASE_URL="postgresql://USER:PASSWORD@HOST/DBNAME?sslmode=require"
 DATABASE_URL_UNPOOLED="postgresql://USER:PASSWORD@HOST/DBNAME?sslmode=require"
 
 # Next.js
+# Local example: http://localhost:3000
+# Preview example: https://your-preview-url.vercel.app
+# Production example: https://bubelpalooza.com
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 NEXTAUTH_URL="http://localhost:3000"
 NODE_ENV="development"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@
 - If a value looks sensitive, keep it out of logs, screenshots, fixtures, tests, and docs.
 - If a secret is exposed, rotate it immediately and update affected systems.
 
+## Deployment Guidance
+
+- Use Vercel as the default hosting platform unless project direction changes.
+- Treat Vercel preview deployments as the default review environment for pull requests.
+- Treat `main` as the production deployment branch for `bubelpalooza.com`.
+- Do not commit Vercel project tokens, generated local Vercel config, or production environment exports.
+- Prefer Vercel defaults unless a repo-level config file is clearly needed.
+- Document any hosted environment variable requirements in repo docs and `.env.example`, but keep real hosted values in Vercel only.
+
 ## Database And Migration Guidance
 
 - Use Drizzle ORM with Neon Postgres.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,37 @@ npm run dev
 - Use separate values for local, preview, and production environments whenever possible.
 - Rotate any secret immediately if it is ever exposed.
 
+## Deployment
+
+- The intended hosting platform is Vercel.
+- Pull requests and non-`main` branches should use Vercel preview deployments.
+- The `main` branch should be the only branch that deploys to the production domain.
+- Production domain target: `bubelpalooza.com`
+- Preview URLs should be used for review instead of maintaining a separate shared staging domain at this stage.
+
+### Vercel Setup
+
+1. Create or open the Vercel project for this repository.
+2. Connect the GitHub repository to Vercel.
+3. Set the production branch to `main`.
+4. Add the production domain `bubelpalooza.com`.
+5. Allow Vercel to post preview deployment checks to pull requests.
+6. Configure environment variables in Vercel rather than committing them.
+
+### Hosted Environment Variables
+
+- For the current frontend-only phase, `NEXT_PUBLIC_APP_URL` is the most important hosted value.
+- In preview environments, set `NEXT_PUBLIC_APP_URL` to the preview deployment URL pattern you want to rely on, or manage it per-environment in Vercel.
+- In production, set `NEXT_PUBLIC_APP_URL` to `https://bubelpalooza.com`.
+- Add database, Stripe, Resend, Twilio, and Sentry values in Vercel only when those features are implemented.
+
+### Deployment Workflow
+
+- Feature branches open pull requests and receive Vercel preview deployments.
+- Reviewers use the preview URL attached to the pull request for QA and design review.
+- Merges to `main` trigger the production deployment.
+- Keep preview and production configuration separate where values differ.
+
 ## Security And Data Handling
 
 - Do not commit secrets, API keys, webhook signing secrets, exports, or customer data.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,68 @@
+# Deployment
+
+## Goal
+
+Use Vercel preview deployments for pull request review and deploy production only from `main` to `bubelpalooza.com`.
+
+## Intended Model
+
+- Pull request branches get their own Vercel preview deployment
+- GitHub pull requests show a preview URL for review
+- The `main` branch deploys to `bubelpalooza.com`
+- No shared staging domain is required at this stage
+
+## What Lives In The Repo
+
+- Deployment expectations and workflow documentation
+- `.env.example` placeholders
+- App code that builds cleanly in production mode
+
+## What Should Not Live In The Repo
+
+- Real production secrets
+- Vercel access tokens
+- Downloaded environment exports
+- Generated local Vercel config that contains project-specific values unless intentionally reviewed
+
+## Manual Vercel Setup
+
+1. Create or select the Vercel project.
+2. Import the GitHub repository.
+3. Confirm the framework is detected as Next.js.
+4. Set the production branch to `main`.
+5. Add `bubelpalooza.com` as the production domain.
+6. Confirm preview deployments are enabled for pull requests.
+7. Add hosted environment variables in Vercel.
+
+## Hosted Environment Variables
+
+### Current Frontend-Only Minimum
+
+- `NEXT_PUBLIC_APP_URL`
+
+### Future Values
+
+Add these in Vercel when the related features are implemented:
+
+- `DATABASE_URL`
+- `DATABASE_URL_UNPOOLED`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
+- `RESEND_API_KEY`
+- `RESEND_FROM_EMAIL`
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- `TWILIO_PHONE_NUMBER`
+- `SENTRY_DSN`
+- `NEXT_PUBLIC_SENTRY_DSN`
+- `SENTRY_AUTH_TOKEN`
+
+## Review Workflow
+
+1. Push a feature branch.
+2. Open a pull request.
+3. Wait for the Vercel preview deployment to appear on the pull request.
+4. Review the preview URL before merge.
+5. Merge to `main` when approved.
+6. Let Vercel deploy production from `main`.


### PR DESCRIPTION
## Summary

- document the intended Vercel deployment model for this repo
- add explicit guidance for PR preview deployments and production-only deploys from main
- clarify hosted environment variable expectations in .env.example
- add a dedicated deployment guide for manual Vercel setup and review workflow

## Linked Issue

Closes #18

## Testing

- 
pm run build

## Notes

- this implementation stays intentionally repo-side only and does not commit Vercel project files, secrets, or dashboard-generated values
- manual Vercel project connection, domain setup, and hosted environment variable entry still need to be completed outside the repo
