### PR TITLE
Add Zod-based environment variable validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ DATABASE_URL_UNPOOLED="postgresql://USER:PASSWORD@HOST/DBNAME?sslmode=require"
 # Preview example: https://your-preview-url.vercel.app
 # Production example: https://bubelpalooza.com
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
-NEXTAUTH_URL="http://localhost:3000"
 NODE_ENV="development"
 
 # Stripe

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ npm run dev
 - Production secrets should be stored in the deployment platform, not in the repository.
 - Use separate values for local, preview, and production environments whenever possible.
 - Rotate any secret immediately if it is ever exposed.
+- Public env reads should go through `lib/env/public.ts`.
+- Server-only env reads should go through `lib/env/server.ts`.
+- Empty provider values can stay unset until the related feature is implemented, but malformed configured values should fail fast.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ npm run dev
 - Public env reads should go through `lib/env/public.ts`.
 - Server-only env reads should go through `lib/env/server.ts`.
 - Empty provider values can stay unset until the related feature is implemented, but malformed configured values should fail fast.
+- `NEXT_PUBLIC_APP_URL` is the local/non-Vercel override for the app base URL.
+- On Vercel, preview and production deployments can derive the app URL from Vercel system environment variables when those are enabled in project settings.
 
 ## Deployment
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { Anton, Geist_Mono, Work_Sans } from "next/font/google";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
-import { publicEnv } from "@/lib/env/public";
-import { ensureServerEnv } from "@/lib/env/server";
+import { ensureServerEnv, serverEnv } from "@/lib/env/server";
 import "./globals.css";
 
 const workSans = Work_Sans({
@@ -28,7 +27,7 @@ const siteDescription =
 ensureServerEnv();
 
 export const metadata: Metadata = {
-  metadataBase: new URL(publicEnv.NEXT_PUBLIC_APP_URL),
+  metadataBase: new URL(serverEnv.APP_URL),
   title: {
     default: "Bubelpalooza",
     template: "%s | Bubelpalooza",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Anton, Geist_Mono, Work_Sans } from "next/font/google";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { publicEnv } from "@/lib/env/public";
+import { ensureServerEnv } from "@/lib/env/server";
 import "./globals.css";
 
 const workSans = Work_Sans({
@@ -23,8 +25,10 @@ const anton = Anton({
 const siteDescription =
   "Bubelpalooza is Sunday, May 24, 2026 at Bubel Beach Club in Leander, TX, with a crawfish boil, pool party, and live music.";
 
+ensureServerEnv();
+
 export const metadata: Metadata = {
-  metadataBase: new URL("https://bubelpalooza.com"),
+  metadataBase: new URL(publicEnv.NEXT_PUBLIC_APP_URL),
   title: {
     default: "Bubelpalooza",
     template: "%s | Bubelpalooza",

--- a/lib/env/public.ts
+++ b/lib/env/public.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { envUrl, formatEnvErrors, optionalSecret, optionalUrl } from "@/lib/env/shared";
+
+const publicEnvSchema = z.object({
+  NEXT_PUBLIC_APP_URL: envUrl,
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: optionalSecret,
+  NEXT_PUBLIC_SENTRY_DSN: optionalUrl,
+});
+
+const publicEnvResult = publicEnvSchema.safeParse({
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+  NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+});
+
+if (!publicEnvResult.success) {
+  throw new Error(formatEnvErrors(publicEnvResult.error, "public"));
+}
+
+export const publicEnv = publicEnvResult.data;
+
+export type PublicEnv = typeof publicEnv;

--- a/lib/env/public.ts
+++ b/lib/env/public.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { envUrl, formatEnvErrors, optionalSecret, optionalUrl } from "@/lib/env/shared";
+import { formatEnvErrors, optionalSecret, optionalUrl } from "@/lib/env/shared";
 
 const publicEnvSchema = z.object({
-  NEXT_PUBLIC_APP_URL: envUrl,
+  NEXT_PUBLIC_APP_URL: optionalUrl,
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: optionalSecret,
   NEXT_PUBLIC_SENTRY_DSN: optionalUrl,
 });

--- a/lib/env/server.ts
+++ b/lib/env/server.ts
@@ -1,10 +1,14 @@
 import { z } from "zod";
 import {
+  envUrl,
   formatEnvErrors,
+  optionalDomain,
   optionalEmail,
+  optionalEnv,
   optionalPhoneNumber,
   optionalSecret,
   optionalUrl,
+  toHttpsUrl,
 } from "@/lib/env/shared";
 import { publicEnv } from "@/lib/env/public";
 
@@ -21,6 +25,11 @@ const serverEnvSchema = z.object({
   TWILIO_PHONE_NUMBER: optionalPhoneNumber,
   SENTRY_DSN: optionalUrl,
   SENTRY_AUTH_TOKEN: optionalSecret,
+  VERCEL_ENV: optionalEnv(z.enum(["production", "preview", "development"])),
+  VERCEL_TARGET_ENV: optionalSecret,
+  VERCEL_URL: optionalDomain,
+  VERCEL_BRANCH_URL: optionalDomain,
+  VERCEL_PROJECT_PRODUCTION_URL: optionalDomain,
 });
 
 const serverEnvResult = serverEnvSchema.safeParse({
@@ -36,15 +45,50 @@ const serverEnvResult = serverEnvSchema.safeParse({
   TWILIO_PHONE_NUMBER: process.env.TWILIO_PHONE_NUMBER,
   SENTRY_DSN: process.env.SENTRY_DSN,
   SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+  VERCEL_TARGET_ENV: process.env.VERCEL_TARGET_ENV,
+  VERCEL_URL: process.env.VERCEL_URL,
+  VERCEL_BRANCH_URL: process.env.VERCEL_BRANCH_URL,
+  VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
 });
 
 if (!serverEnvResult.success) {
   throw new Error(formatEnvErrors(serverEnvResult.error, "server"));
 }
 
+const parsedServerEnv = serverEnvResult.data;
+
+function resolveAppUrl() {
+  if (publicEnv.NEXT_PUBLIC_APP_URL) {
+    return publicEnv.NEXT_PUBLIC_APP_URL;
+  }
+
+  const vercelCandidate =
+    parsedServerEnv.VERCEL_ENV === "preview"
+      ? parsedServerEnv.VERCEL_BRANCH_URL ?? parsedServerEnv.VERCEL_URL
+      : parsedServerEnv.VERCEL_PROJECT_PRODUCTION_URL ?? parsedServerEnv.VERCEL_URL;
+
+  const appUrlResult = envUrl.safeParse(
+    vercelCandidate ? toHttpsUrl(vercelCandidate) : undefined,
+  );
+
+  if (!appUrlResult.success) {
+    throw new Error(
+      [
+        "Invalid application URL configuration:",
+        "- Set NEXT_PUBLIC_APP_URL for local development and non-Vercel environments.",
+        "- Or enable Vercel system environment variables for preview and production deployments.",
+      ].join("\n"),
+    );
+  }
+
+  return appUrlResult.data;
+}
+
 export const serverEnv = {
-  ...serverEnvResult.data,
+  ...parsedServerEnv,
   ...publicEnv,
+  APP_URL: resolveAppUrl(),
 };
 
 export function ensureServerEnv() {

--- a/lib/env/server.ts
+++ b/lib/env/server.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import {
+  formatEnvErrors,
+  optionalEmail,
+  optionalPhoneNumber,
+  optionalSecret,
+  optionalUrl,
+} from "@/lib/env/shared";
+import { publicEnv } from "@/lib/env/public";
+
+const serverEnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "test", "production"]),
+  DATABASE_URL: optionalUrl,
+  DATABASE_URL_UNPOOLED: optionalUrl,
+  STRIPE_SECRET_KEY: optionalSecret,
+  STRIPE_WEBHOOK_SECRET: optionalSecret,
+  RESEND_API_KEY: optionalSecret,
+  RESEND_FROM_EMAIL: optionalEmail,
+  TWILIO_ACCOUNT_SID: optionalSecret,
+  TWILIO_AUTH_TOKEN: optionalSecret,
+  TWILIO_PHONE_NUMBER: optionalPhoneNumber,
+  SENTRY_DSN: optionalUrl,
+  SENTRY_AUTH_TOKEN: optionalSecret,
+});
+
+const serverEnvResult = serverEnvSchema.safeParse({
+  NODE_ENV: process.env.NODE_ENV,
+  DATABASE_URL: process.env.DATABASE_URL,
+  DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
+  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+  STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+  RESEND_API_KEY: process.env.RESEND_API_KEY,
+  RESEND_FROM_EMAIL: process.env.RESEND_FROM_EMAIL,
+  TWILIO_ACCOUNT_SID: process.env.TWILIO_ACCOUNT_SID,
+  TWILIO_AUTH_TOKEN: process.env.TWILIO_AUTH_TOKEN,
+  TWILIO_PHONE_NUMBER: process.env.TWILIO_PHONE_NUMBER,
+  SENTRY_DSN: process.env.SENTRY_DSN,
+  SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+});
+
+if (!serverEnvResult.success) {
+  throw new Error(formatEnvErrors(serverEnvResult.error, "server"));
+}
+
+export const serverEnv = {
+  ...serverEnvResult.data,
+  ...publicEnv,
+};
+
+export function ensureServerEnv() {
+  return serverEnv;
+}
+
+export type ServerEnv = typeof serverEnv;

--- a/lib/env/shared.ts
+++ b/lib/env/shared.ts
@@ -34,6 +34,15 @@ export const optionalPhoneNumber = optionalEnv(
 
 export const optionalSecret = optionalEnv(z.string().trim().min(1, "cannot be empty"));
 
+export const optionalDomain = optionalEnv(
+  z
+    .string()
+    .trim()
+    .min(1, "cannot be empty")
+    .refine((value) => !value.includes("://"), "must be a domain without a protocol")
+    .refine((value) => !value.includes("/"), "must not include a path"),
+);
+
 const formatPath = (path: PropertyKey[]) => path.join(".");
 
 export function formatEnvErrors(error: z.ZodError, label: string) {
@@ -43,4 +52,8 @@ export function formatEnvErrors(error: z.ZodError, label: string) {
   });
 
   return [`Invalid ${label} environment variables:`, ...issues].join("\n");
+}
+
+export function toHttpsUrl(domain: string) {
+  return `https://${domain}`;
 }

--- a/lib/env/shared.ts
+++ b/lib/env/shared.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+const emptyStringToUndefined = (value: unknown) =>
+  typeof value === "string" && value.trim() === "" ? undefined : value;
+
+const validUrl = (value: string) => {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const optionalEnv = <T extends z.ZodType>(schema: T) =>
+  z.preprocess(emptyStringToUndefined, schema.optional());
+
+export const envUrl = z
+  .string()
+  .trim()
+  .min(1, "is required")
+  .refine(validUrl, "must be a valid URL");
+
+export const optionalUrl = optionalEnv(envUrl);
+
+export const optionalEmail = optionalEnv(z.string().trim().email("must be a valid email address"));
+
+export const optionalPhoneNumber = optionalEnv(
+  z
+    .string()
+    .trim()
+    .regex(/^\+[1-9]\d{1,14}$/, "must be a valid E.164 phone number"),
+);
+
+export const optionalSecret = optionalEnv(z.string().trim().min(1, "cannot be empty"));
+
+const formatPath = (path: PropertyKey[]) => path.join(".");
+
+export function formatEnvErrors(error: z.ZodError, label: string) {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? formatPath(issue.path) : "value";
+    return `- ${path}: ${issue.message}`;
+  });
+
+  return [`Invalid ${label} environment variables:`, ...issues].join("\n");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "19.2.4",
         "shadcn": "^4.5.0",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -10986,9 +10987,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "19.2.4",
     "shadcn": "^4.5.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- add a small Zod-based env validation layer with separate public and server entry points
- validate env on app startup and use the validated public app URL for metadataBase
- align `.env.example` and README guidance with the new env access pattern

## Testing
- npm run lint
- npx tsc --noEmit
- `$env:NEXT_PUBLIC_APP_URL='http://localhost:3000'; npm run build`

Closes #6
