### PR TITLE
Add modal signup flow for event update announcements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@
 - Use `.env.local` for local development and platform-managed environment variables for hosted environments.
 - If a value looks sensitive, keep it out of logs, screenshots, fixtures, tests, and docs.
 - If a secret is exposed, rotate it immediately and update affected systems.
+- When a shipped feature depends on environment variables in a deployed environment, those variables should become required application configuration and should fail fast at startup if they are missing.
 
 ## Deployment Guidance
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm run dev
 - Empty provider values can stay unset until they are needed, but malformed configured values should fail fast.
 - `NEXT_PUBLIC_APP_URL` is the local/non-Vercel override for the app base URL.
 - On Vercel, preview and production deployments can derive the app URL from Vercel system environment variables when those are enabled in project settings.
-- `DATABASE_URL` and `DATABASE_URL_UNPOOLED` are reserved for the Drizzle + Neon database foundation.
+- At least one of `DATABASE_URL` or `DATABASE_URL_UNPOOLED` must be configured for deployed environments because database-backed features fail fast at startup.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm run dev
 - Public env reads should go through `lib/env/public.ts`.
 - Server-only env reads should go through `lib/env/server.ts`.
 - Empty provider values can stay unset until they are needed, but malformed configured values should fail fast.
+- When a deployed feature depends on environment variables, those variables should become required configuration and should fail the application at startup if they are missing.
 - `NEXT_PUBLIC_APP_URL` is the local/non-Vercel override for the app base URL.
 - On Vercel, preview and production deployments can derive the app URL from Vercel system environment variables when those are enabled in project settings.
 - At least one of `DATABASE_URL` or `DATABASE_URL_UNPOOLED` must be configured for deployed environments because database-backed features fail fast at startup.

--- a/app/api/event-updates-signups/route.ts
+++ b/app/api/event-updates-signups/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+import { saveEventUpdateSignup } from "@/lib/event-updates/service";
+import { eventUpdateSignupSchema } from "@/lib/event-updates/schema";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const parsed = eventUpdateSignupSchema.parse(body);
+    const result = await saveEventUpdateSignup(parsed);
+
+    return NextResponse.json({
+      ok: true,
+      status: result.status,
+      message:
+        "You are on the list for Bubelpalooza announcements, including ticket on-sale updates.",
+    });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const fieldErrors = error.flatten().fieldErrors;
+
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "Please check the form and try again.",
+          fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+
+    console.error("Failed to save event update signup", error);
+
+    return NextResponse.json(
+      {
+        ok: false,
+        message:
+          "We could not save your signup right now. Please try again in a moment.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { EventUpdatesModal } from "@/components/event-updates-modal";
 import { Anton, Geist_Mono, Work_Sans } from "next/font/google";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
@@ -80,6 +81,7 @@ export default function RootLayout({
           <main className="flex-1">{children}</main>
           <SiteFooter />
         </div>
+        <EventUpdatesModal />
       </body>
     </html>
   );

--- a/components/event-updates-modal.tsx
+++ b/components/event-updates-modal.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  EVENT_UPDATES_AUTO_OPEN_DELAY_MS,
+  EVENT_UPDATES_DISMISS_DAYS,
+  EVENT_UPDATES_MODAL_EVENT,
+  EVENT_UPDATES_STORAGE_KEYS,
+} from "@/lib/event-updates/constants";
+
+type FieldErrors = Partial<Record<"firstName" | "lastName" | "email", string[]>>;
+
+const initialFormState = {
+  firstName: "",
+  lastName: "",
+  email: "",
+};
+
+function hasDismissalExpired(timestamp: string | null) {
+  if (!timestamp) {
+    return true;
+  }
+
+  const dismissedAt = Number(timestamp);
+
+  if (Number.isNaN(dismissedAt)) {
+    return true;
+  }
+
+  return Date.now() - dismissedAt > EVENT_UPDATES_DISMISS_DAYS * 24 * 60 * 60 * 1000;
+}
+
+export function EventUpdatesModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return Boolean(window.localStorage.getItem(EVENT_UPDATES_STORAGE_KEYS.submittedAt));
+  });
+  const [formValues, setFormValues] = useState(initialFormState);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [requestError, setRequestError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const openModal = () => {
+      setRequestError(null);
+      setFieldErrors({});
+      setIsOpen(true);
+    };
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isOpen) {
+        closeModal();
+      }
+    };
+
+    window.addEventListener(EVENT_UPDATES_MODAL_EVENT, openModal);
+    window.addEventListener("keydown", closeOnEscape);
+
+    let timeout: number | null = null;
+
+    if (!isSubmitted) {
+      timeout = window.setTimeout(() => {
+        const dismissedAt = window.localStorage.getItem(EVENT_UPDATES_STORAGE_KEYS.dismissedAt);
+
+        if (hasDismissalExpired(dismissedAt)) {
+          setIsOpen(true);
+        }
+      }, EVENT_UPDATES_AUTO_OPEN_DELAY_MS);
+    }
+
+    return () => {
+      if (timeout !== null) {
+        window.clearTimeout(timeout);
+      }
+      window.removeEventListener(EVENT_UPDATES_MODAL_EVENT, openModal);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [isOpen, isSubmitted]);
+
+  const successMessage = useMemo(
+    () =>
+      "You are on the list. We will send announcements when tickets go on sale and when new event details are ready.",
+    [],
+  );
+
+  function closeModal() {
+    setIsOpen(false);
+    window.localStorage.setItem(
+      EVENT_UPDATES_STORAGE_KEYS.dismissedAt,
+      String(Date.now()),
+    );
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setRequestError(null);
+    setFieldErrors({});
+
+    try {
+      const response = await fetch("/api/event-updates-signups", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...formValues,
+          source: "site-modal",
+        }),
+      });
+
+      const data = (await response.json()) as {
+        ok: boolean;
+        message?: string;
+        fieldErrors?: FieldErrors;
+      };
+
+      if (!response.ok || !data.ok) {
+        setFieldErrors(data.fieldErrors ?? {});
+        setRequestError(data.message ?? "Please try again.");
+        return;
+      }
+
+      setIsSubmitted(true);
+      setIsOpen(true);
+      window.localStorage.setItem(
+        EVENT_UPDATES_STORAGE_KEYS.submittedAt,
+        String(Date.now()),
+      );
+      window.localStorage.removeItem(EVENT_UPDATES_STORAGE_KEYS.dismissedAt);
+    } catch {
+      setRequestError("We could not save your signup right now. Please try again in a moment.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-end justify-center bg-[#101827]/78 px-4 py-4 sm:items-center sm:px-6">
+      <div className="poster-panel relative w-full max-w-2xl border-4 border-[#102344] bg-[#ffd447] p-5 text-[#102344] shadow-[12px_12px_0_#102344] sm:p-8">
+        <button
+          type="button"
+          onClick={closeModal}
+          className="absolute right-3 top-3 inline-flex h-11 w-11 items-center justify-center border-2 border-[#102344] bg-[#fff7e6] text-[#102344] shadow-[3px_3px_0_#102344] hover:bg-white"
+          aria-label="Close updates signup"
+        >
+          <X className="size-5" />
+        </button>
+
+        <div className="pr-12">
+          <p className="inline-block bg-[#102344] px-3 py-1 text-xs font-black uppercase text-[#ffd447] shadow-[4px_4px_0_#e6392e]">
+            Stay up to date
+          </p>
+          <h2 data-poster="true" className="mt-4 text-5xl leading-[0.88] text-[#e6392e] sm:text-6xl">
+            GET ANNOUNCEMENTS
+          </h2>
+          <p className="mt-4 max-w-xl text-base font-semibold leading-7 text-[#24344d] sm:text-lg">
+            Be first to hear when tickets go on sale and when Bubelpalooza shares
+            lineup, merch, and day-of updates.
+          </p>
+        </div>
+
+        {isSubmitted ? (
+          <div className="mt-6 border-4 border-[#102344] bg-[#fff7e6] p-5 shadow-[8px_8px_0_#102344]">
+            <p className="text-lg font-black uppercase text-[#102344]">You are on the list</p>
+            <p className="mt-3 text-base font-semibold leading-7 text-[#344760]">
+              {successMessage}
+            </p>
+            <Button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="mt-5 h-auto rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-6 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-[#6fd8f7]"
+            >
+              Back to the party
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-2 block text-sm font-black uppercase text-[#102344]">
+                  First name
+                </span>
+                <input
+                  type="text"
+                  name="firstName"
+                  value={formValues.firstName}
+                  onChange={(event) =>
+                    setFormValues((current) => ({
+                      ...current,
+                      firstName: event.target.value,
+                    }))
+                  }
+                  className="w-full border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-base font-semibold text-[#102344] shadow-[5px_5px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white"
+                  autoComplete="given-name"
+                />
+                {fieldErrors.firstName?.[0] ? (
+                  <span className="mt-2 block text-sm font-bold text-[#e6392e]">
+                    First name {fieldErrors.firstName[0]}
+                  </span>
+                ) : null}
+              </label>
+
+              <label className="block">
+                <span className="mb-2 block text-sm font-black uppercase text-[#102344]">
+                  Last name
+                </span>
+                <input
+                  type="text"
+                  name="lastName"
+                  value={formValues.lastName}
+                  onChange={(event) =>
+                    setFormValues((current) => ({
+                      ...current,
+                      lastName: event.target.value,
+                    }))
+                  }
+                  className="w-full border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-base font-semibold text-[#102344] shadow-[5px_5px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white"
+                  autoComplete="family-name"
+                />
+                {fieldErrors.lastName?.[0] ? (
+                  <span className="mt-2 block text-sm font-bold text-[#e6392e]">
+                    Last name {fieldErrors.lastName[0]}
+                  </span>
+                ) : null}
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="mb-2 block text-sm font-black uppercase text-[#102344]">
+                Email
+              </span>
+              <input
+                type="email"
+                name="email"
+                value={formValues.email}
+                onChange={(event) =>
+                  setFormValues((current) => ({
+                    ...current,
+                    email: event.target.value,
+                  }))
+                }
+                className="w-full border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-base font-semibold text-[#102344] shadow-[5px_5px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white"
+                autoComplete="email"
+              />
+              {fieldErrors.email?.[0] ? (
+                <span className="mt-2 block text-sm font-bold text-[#e6392e]">
+                  Email {fieldErrors.email[0]}
+                </span>
+              ) : null}
+            </label>
+
+            {requestError ? (
+              <p className="border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-sm font-bold text-[#e6392e] shadow-[5px_5px_0_#102344]">
+                {requestError}
+              </p>
+            ) : null}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="max-w-xl text-sm font-semibold leading-6 text-[#344760]">
+                Sign up once and stay in the loop for ticket on-sale announcements and
+                key event updates.
+              </p>
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="h-auto rounded-none border-4 border-[#102344] bg-[#e6392e] px-6 py-3 text-sm font-black uppercase text-white shadow-[5px_5px_0_#102344] hover:bg-[#cf2f24] disabled:translate-y-0 disabled:opacity-100"
+              >
+                {isSubmitting ? "Saving..." : "Get announcements"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/event-updates-modal.tsx
+++ b/components/event-updates-modal.tsx
@@ -85,7 +85,7 @@ export function EventUpdatesModal() {
 
   const successMessage = useMemo(
     () =>
-      "You are on the list. We will send announcements when tickets go on sale and when new event details are ready.",
+      "We will send announcements when tickets go on sale and when new event details are ready.",
     [],
   );
 
@@ -151,7 +151,7 @@ export function EventUpdatesModal() {
         <button
           type="button"
           onClick={closeModal}
-          className="absolute right-3 top-3 inline-flex h-11 w-11 items-center justify-center border-2 border-[#102344] bg-[#fff7e6] text-[#102344] shadow-[3px_3px_0_#102344] hover:bg-white"
+          className="absolute right-3 top-3 inline-flex h-11 w-11 cursor-pointer items-center justify-center border-2 border-[#102344] bg-[#fff7e6] text-[#102344] shadow-[3px_3px_0_#102344] hover:bg-white"
           aria-label="Close updates signup"
         >
           <X className="size-5" />

--- a/components/event-updates-trigger.tsx
+++ b/components/event-updates-trigger.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { EVENT_UPDATES_MODAL_EVENT } from "@/lib/event-updates/constants";
+
+export function EventUpdatesTrigger() {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      onClick={() => window.dispatchEvent(new CustomEvent(EVENT_UPDATES_MODAL_EVENT))}
+      className="inline-flex self-center rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-3 py-3 text-xs font-black uppercase text-[#102344] shadow-[4px_4px_0_#102344] hover:bg-[#6fd8f7] sm:px-4 sm:py-5 sm:text-sm sm:shadow-[5px_5px_0_#102344]"
+    >
+      Get updates
+    </Button>
+  );
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { EventUpdatesTrigger } from "@/components/event-updates-trigger";
 
 export function SiteHeader() {
   return (
@@ -39,13 +39,7 @@ export function SiteHeader() {
           ))}
         </nav>
 
-        <Button
-          asChild
-          size="sm"
-          className="hidden self-center rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-4 py-5 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-[#6fd8f7] sm:inline-flex"
-        >
-          <a href="#tickets">Ticket info soon</a>
-        </Button>
+        <EventUpdatesTrigger />
       </div>
     </header>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/docs/database.md
+++ b/docs/database.md
@@ -20,7 +20,7 @@ The database foundation expects one of these variables when you run Drizzle comm
 - `DATABASE_URL`
 - `DATABASE_URL_UNPOOLED`
 
-Runtime app code prefers `DATABASE_URL` first and falls back to `DATABASE_URL_UNPOOLED`.
+Runtime app code requires at least one database URL at startup, prefers `DATABASE_URL` first, and falls back to `DATABASE_URL_UNPOOLED`.
 
 Drizzle commands prefer `DATABASE_URL_UNPOOLED` first and fall back to `DATABASE_URL`.
 

--- a/drizzle/0000_deep_quasar.sql
+++ b/drizzle/0000_deep_quasar.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "event_update_signups" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"email" text NOT NULL,
+	"source" text NOT NULL,
+	"status" text DEFAULT 'subscribed' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "event_update_signups_email_unique" UNIQUE("email")
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,92 @@
+{
+  "id": "6714a74f-58f0-4738-9855-ba627f7cbe57",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.event_update_signups": {
+      "name": "event_update_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_update_signups_email_unique": {
+          "name": "event_update_signups_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1778113556900,
+      "tag": "0000_deep_quasar",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -1,2 +1,15 @@
-// Export Drizzle tables from this module as the schema grows.
-export {};
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const eventUpdateSignups = pgTable("event_update_signups", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  email: text("email").notNull().unique(),
+  source: text("source").notNull(),
+  status: text("status").notNull().default("subscribed"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type EventUpdateSignup = typeof eventUpdateSignups.$inferSelect;
+export type NewEventUpdateSignup = typeof eventUpdateSignups.$inferInsert;

--- a/lib/env/server.ts
+++ b/lib/env/server.ts
@@ -12,25 +12,35 @@ import {
 } from "@/lib/env/shared";
 import { publicEnv } from "@/lib/env/public";
 
-const serverEnvSchema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]),
-  DATABASE_URL: optionalUrl,
-  DATABASE_URL_UNPOOLED: optionalUrl,
-  STRIPE_SECRET_KEY: optionalSecret,
-  STRIPE_WEBHOOK_SECRET: optionalSecret,
-  RESEND_API_KEY: optionalSecret,
-  RESEND_FROM_EMAIL: optionalEmail,
-  TWILIO_ACCOUNT_SID: optionalSecret,
-  TWILIO_AUTH_TOKEN: optionalSecret,
-  TWILIO_PHONE_NUMBER: optionalPhoneNumber,
-  SENTRY_DSN: optionalUrl,
-  SENTRY_AUTH_TOKEN: optionalSecret,
-  VERCEL_ENV: optionalEnv(z.enum(["production", "preview", "development"])),
-  VERCEL_TARGET_ENV: optionalSecret,
-  VERCEL_URL: optionalDomain,
-  VERCEL_BRANCH_URL: optionalDomain,
-  VERCEL_PROJECT_PRODUCTION_URL: optionalDomain,
-});
+const serverEnvSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]),
+    DATABASE_URL: optionalUrl,
+    DATABASE_URL_UNPOOLED: optionalUrl,
+    STRIPE_SECRET_KEY: optionalSecret,
+    STRIPE_WEBHOOK_SECRET: optionalSecret,
+    RESEND_API_KEY: optionalSecret,
+    RESEND_FROM_EMAIL: optionalEmail,
+    TWILIO_ACCOUNT_SID: optionalSecret,
+    TWILIO_AUTH_TOKEN: optionalSecret,
+    TWILIO_PHONE_NUMBER: optionalPhoneNumber,
+    SENTRY_DSN: optionalUrl,
+    SENTRY_AUTH_TOKEN: optionalSecret,
+    VERCEL_ENV: optionalEnv(z.enum(["production", "preview", "development"])),
+    VERCEL_TARGET_ENV: optionalSecret,
+    VERCEL_URL: optionalDomain,
+    VERCEL_BRANCH_URL: optionalDomain,
+    VERCEL_PROJECT_PRODUCTION_URL: optionalDomain,
+  })
+  .superRefine((env, context) => {
+    if (!env.DATABASE_URL && !env.DATABASE_URL_UNPOOLED) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["DATABASE_URL"],
+        message: "or DATABASE_URL_UNPOOLED is required",
+      });
+    }
+  });
 
 const serverEnvResult = serverEnvSchema.safeParse({
   NODE_ENV: process.env.NODE_ENV,

--- a/lib/event-updates/constants.ts
+++ b/lib/event-updates/constants.ts
@@ -1,0 +1,8 @@
+export const EVENT_UPDATES_STORAGE_KEYS = {
+  dismissedAt: "bubelpalooza-event-updates-dismissed-at",
+  submittedAt: "bubelpalooza-event-updates-submitted-at",
+} as const;
+
+export const EVENT_UPDATES_MODAL_EVENT = "bubelpalooza:event-updates:open";
+export const EVENT_UPDATES_DISMISS_DAYS = 14;
+export const EVENT_UPDATES_AUTO_OPEN_DELAY_MS = 4500;

--- a/lib/event-updates/schema.ts
+++ b/lib/event-updates/schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const nameSchema = z
+  .string()
+  .trim()
+  .min(1, "is required")
+  .max(80, "must be 80 characters or fewer");
+
+export const eventUpdateSignupSchema = z.object({
+  firstName: nameSchema,
+  lastName: nameSchema,
+  email: z.string().trim().min(1, "is required").email("must be a valid email address"),
+  source: z.string().trim().min(1).max(50),
+});
+
+export type EventUpdateSignupInput = z.infer<typeof eventUpdateSignupSchema>;

--- a/lib/event-updates/service.ts
+++ b/lib/event-updates/service.ts
@@ -1,0 +1,46 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import { eventUpdateSignups } from "@/lib/db/schema";
+import {
+  type EventUpdateSignupInput,
+  eventUpdateSignupSchema,
+} from "@/lib/event-updates/schema";
+
+function normalizeSignup(input: EventUpdateSignupInput) {
+  return {
+    firstName: input.firstName.trim(),
+    lastName: input.lastName.trim(),
+    email: input.email.trim().toLowerCase(),
+    source: input.source.trim(),
+  };
+}
+
+export async function saveEventUpdateSignup(input: EventUpdateSignupInput) {
+  const parsed = eventUpdateSignupSchema.parse(input);
+  const signup = normalizeSignup(parsed);
+  const db = getDb();
+
+  const existingSignup = await db.query.eventUpdateSignups.findFirst({
+    where: eq(eventUpdateSignups.email, signup.email),
+  });
+
+  if (existingSignup) {
+    return {
+      status: "duplicate" as const,
+      signup: existingSignup,
+    };
+  }
+
+  const [createdSignup] = await db
+    .insert(eventUpdateSignups)
+    .values({
+      ...signup,
+      status: "subscribed",
+    })
+    .returning();
+
+  return {
+    status: "created" as const,
+    signup: createdSignup,
+  };
+}


### PR DESCRIPTION
## Summary
- add a first-visit event updates modal with a header CTA to reopen it and guest-facing "Stay up to date" / "Get announcements" copy
- add required first name, last name, and email validation with a server-side signup API
- persist signups to Neon through Drizzle, generate the signup migration, and dedupe repeat submissions by email

## Testing
- npm run db:generate
- npm run db:migrate
- npm run lint
- npx tsc --noEmit
- `$env:NEXT_PUBLIC_APP_URL='http://localhost:3000'; npm run build`
- verified live database behavior with a temporary signup test: first submission inserted, second submission with the same email returned duplicate, and only one row existed

Closes #40
