### PR TITLE
Add event updates welcome email flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_your_value_here"
 
 # Resend
 RESEND_API_KEY="re_your_value_here"
-RESEND_FROM_EMAIL="tickets@example.com"
+RESEND_FROM_EMAIL="Tickets <tickets@example.com>"
 
 # Twilio
 TWILIO_ACCOUNT_SID="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ npm run dev
 - In preview environments, set `NEXT_PUBLIC_APP_URL` to the preview deployment URL pattern you want to rely on, or manage it per-environment in Vercel.
 - In production, set `NEXT_PUBLIC_APP_URL` to `https://bubelpalooza.com`.
 - Add database, Stripe, Resend, Twilio, and Sentry values in Vercel when those services are used by the application.
+- Event updates welcome emails use `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, and the committed Resend template registry in `lib/notifications/resend-templates.ts`. Provider send failures or a missing hosted template ID do not block signup capture.
+- `RESEND_API_KEY` and `RESEND_FROM_EMAIL` are validated during server environment startup, including production builds.
 
 ### Deployment Workflow
 
@@ -128,6 +130,8 @@ The durable visual and copy direction lives in [`docs/theme.md`](docs/theme.md).
 ## Backend Notes
 
 Database setup details live in [`docs/database.md`](docs/database.md).
+
+Notification flow details live in [`docs/notifications.md`](docs/notifications.md).
 
 ## Near-Term Priorities
 

--- a/app/api/event-updates-signups/route.ts
+++ b/app/api/event-updates-signups/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { ZodError } from "zod";
+import { sendEventUpdateWelcomeEmail } from "@/lib/event-updates/email";
 import { saveEventUpdateSignup } from "@/lib/event-updates/service";
 import { eventUpdateSignupSchema } from "@/lib/event-updates/schema";
 
@@ -9,11 +10,25 @@ export async function POST(request: Request) {
     const parsed = eventUpdateSignupSchema.parse(body);
     const result = await saveEventUpdateSignup(parsed);
 
+    if (result.status === "created") {
+      const emailResult = await sendEventUpdateWelcomeEmail(result.signup);
+
+      if (emailResult.status === "skipped") {
+        console.warn(
+          "Event updates welcome email skipped because the hosted template is not configured.",
+        );
+      }
+
+      if (emailResult.status === "failed") {
+        console.warn("Event updates welcome email failed after signup capture.");
+      }
+    }
+
     return NextResponse.json({
       ok: true,
       status: result.status,
       message:
-        "You are on the list for Bubelpalooza announcements, including ticket on-sale updates.",
+        "Thanks for your interest in Bubelpalooza. We will send details as they are ready.",
     });
   } catch (error) {
     if (error instanceof ZodError) {
@@ -29,7 +44,10 @@ export async function POST(request: Request) {
       );
     }
 
-    console.error("Failed to save event update signup", error);
+    console.error(
+      "Failed to save event update signup.",
+      error instanceof Error ? { name: error.name } : undefined,
+    );
 
     return NextResponse.json(
       {

--- a/components/event-updates-modal.tsx
+++ b/components/event-updates-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +18,14 @@ const initialFormState = {
   email: "",
 };
 
+type FormField = keyof typeof initialFormState;
+
+function getFormString(formData: FormData, field: FormField) {
+  const value = formData.get(field);
+
+  return typeof value === "string" ? value : "";
+}
+
 function hasDismissalExpired(timestamp: string | null) {
   if (!timestamp) {
     return true;
@@ -33,15 +41,11 @@ function hasDismissalExpired(timestamp: string | null) {
 }
 
 export function EventUpdatesModal() {
+  const titleId = useId();
+  const descriptionId = useId();
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-
-    return Boolean(window.localStorage.getItem(EVENT_UPDATES_STORAGE_KEYS.submittedAt));
-  });
+  const [isSubmitted, setIsSubmitted] = useState(false);
   const [formValues, setFormValues] = useState(initialFormState);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [requestError, setRequestError] = useState<string | null>(null);
@@ -85,7 +89,7 @@ export function EventUpdatesModal() {
 
   const successMessage = useMemo(
     () =>
-      "We will send announcements when tickets go on sale and when new event details are ready.",
+      "As a reminder, Bubelpalooza is Sunday, May 24, 2026 at Bubel Beach Club in Leander, TX. The pool opens at 12 PM, and we will share more details as they are ready.",
     [],
   );
 
@@ -97,11 +101,37 @@ export function EventUpdatesModal() {
     );
   }
 
+  function updateFormValue(field: FormField, value: string) {
+    setFormValues((current) => ({
+      ...current,
+      [field]: value,
+    }));
+
+    if (fieldErrors[field]?.length) {
+      setFieldErrors((current) => ({
+        ...current,
+        [field]: undefined,
+      }));
+    }
+
+    if (requestError) {
+      setRequestError(null);
+    }
+  }
+
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const submittedValues = {
+      firstName: getFormString(formData, "firstName"),
+      lastName: getFormString(formData, "lastName"),
+      email: getFormString(formData, "email"),
+    };
+
     setIsSubmitting(true);
     setRequestError(null);
     setFieldErrors({});
+    setFormValues(submittedValues);
 
     try {
       const response = await fetch("/api/event-updates-signups", {
@@ -110,7 +140,7 @@ export function EventUpdatesModal() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          ...formValues,
+          ...submittedValues,
           source: "site-modal",
         }),
       });
@@ -129,10 +159,6 @@ export function EventUpdatesModal() {
 
       setIsSubmitted(true);
       setIsOpen(true);
-      window.localStorage.setItem(
-        EVENT_UPDATES_STORAGE_KEYS.submittedAt,
-        String(Date.now()),
-      );
       window.localStorage.removeItem(EVENT_UPDATES_STORAGE_KEYS.dismissedAt);
     } catch {
       setRequestError("We could not save your signup right now. Please try again in a moment.");
@@ -146,63 +172,77 @@ export function EventUpdatesModal() {
   }
 
   return (
-    <div className="fixed inset-0 z-[80] flex items-end justify-center bg-[#101827]/78 px-4 py-4 sm:items-center sm:px-6">
-      <div className="poster-panel relative w-full max-w-2xl border-4 border-[#102344] bg-[#ffd447] p-5 text-[#102344] shadow-[12px_12px_0_#102344] sm:p-8">
+    <div className="fixed inset-0 z-[80] flex items-start justify-center overflow-y-auto bg-[#101827]/78 px-4 py-4 sm:items-center sm:px-6 sm:py-6">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="poster-panel relative mx-auto max-h-[calc(100dvh-2rem)] w-full min-w-0 max-w-[25rem] overflow-y-auto border-4 border-[#102344] bg-[#ffd447] p-4 text-[#102344] shadow-[6px_6px_0_#102344] sm:max-h-[calc(100vh-3rem)] sm:max-w-2xl sm:p-8 sm:shadow-[12px_12px_0_#102344]"
+      >
         <button
           type="button"
           onClick={closeModal}
-          className="absolute right-3 top-3 inline-flex h-11 w-11 cursor-pointer items-center justify-center border-2 border-[#102344] bg-[#fff7e6] text-[#102344] shadow-[3px_3px_0_#102344] hover:bg-white"
+          className="absolute right-2 top-2 inline-flex h-10 w-10 cursor-pointer items-center justify-center border-2 border-[#102344] bg-[#fff7e6] text-[#102344] shadow-[3px_3px_0_#102344] hover:bg-white sm:right-3 sm:top-3 sm:h-11 sm:w-11"
           aria-label="Close updates signup"
         >
           <X className="size-5" />
         </button>
 
-        <div className="pr-12">
-          <p className="inline-block bg-[#102344] px-3 py-1 text-xs font-black uppercase text-[#ffd447] shadow-[4px_4px_0_#e6392e]">
+        <div className="pr-10 sm:pr-12">
+          <p className="inline-block bg-[#102344] px-3 py-1 text-[0.7rem] font-black uppercase text-[#ffd447] shadow-[4px_4px_0_#e6392e] sm:text-xs">
             Stay up to date
           </p>
-          <h2 data-poster="true" className="mt-4 text-5xl leading-[0.88] text-[#e6392e] sm:text-6xl">
-            GET ANNOUNCEMENTS
+          <h2
+            id={titleId}
+            data-poster="true"
+            className="mt-3 text-[2.4rem] leading-[0.88] text-[#e6392e] sm:mt-4 sm:text-6xl"
+          >
+            <span className="block sm:inline">GET</span>{" "}
+            <span className="block sm:inline">ANNOUNCEMENTS</span>
           </h2>
-          <p className="mt-4 max-w-xl text-base font-semibold leading-7 text-[#24344d] sm:text-lg">
+          <p
+            id={descriptionId}
+            className="mt-3 max-w-xl text-sm font-semibold leading-6 text-[#24344d] sm:mt-4 sm:text-lg sm:leading-7"
+          >
             Be first to hear when tickets go on sale and when Bubelpalooza shares
             lineup, merch, and day-of updates.
           </p>
         </div>
 
         {isSubmitted ? (
-          <div className="mt-6 border-4 border-[#102344] bg-[#fff7e6] p-5 shadow-[8px_8px_0_#102344]">
-            <p className="text-lg font-black uppercase text-[#102344]">You are on the list</p>
-            <p className="mt-3 text-base font-semibold leading-7 text-[#344760]">
+          <div className="mt-4 border-4 border-[#102344] bg-[#fff7e6] p-4 shadow-[6px_6px_0_#102344] sm:mt-6 sm:p-5 sm:shadow-[8px_8px_0_#102344]">
+            <p className="text-lg font-black uppercase text-[#102344]">Thanks for your interest</p>
+            <p className="mt-3 text-sm font-semibold leading-6 text-[#344760] sm:text-base sm:leading-7">
               {successMessage}
             </p>
             <Button
               type="button"
               onClick={() => setIsOpen(false)}
-              className="mt-5 h-auto rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-6 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-[#6fd8f7]"
+              className="mt-5 h-auto w-full rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-6 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-[#6fd8f7] sm:w-auto"
             >
               Back to the party
             </Button>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
+          <form onSubmit={handleSubmit} className="mt-4 space-y-3 sm:mt-6 sm:space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2 sm:gap-4">
               <label className="block">
-                <span className="mb-2 block text-sm font-black uppercase text-[#102344]">
+                <span className="mb-1.5 block text-xs font-black uppercase text-[#102344] sm:mb-2 sm:text-sm">
                   First name
                 </span>
                 <input
                   type="text"
                   name="firstName"
                   value={formValues.firstName}
-                  onChange={(event) =>
-                    setFormValues((current) => ({
-                      ...current,
-                      firstName: event.target.value,
-                    }))
+                  onChange={(event) => updateFormValue("firstName", event.target.value)}
+                  onInput={(event) =>
+                    updateFormValue("firstName", event.currentTarget.value)
                   }
-                  className="w-full border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-base font-semibold text-[#102344] shadow-[5px_5px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white"
+                  className="w-full border-4 border-[#102344] bg-[#fff7e6] px-3 py-2.5 text-base font-semibold text-[#102344] shadow-[4px_4px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white sm:px-4 sm:py-3 sm:shadow-[5px_5px_0_#102344]"
                   autoComplete="given-name"
+                  required
+                  aria-invalid={Boolean(fieldErrors.firstName?.[0])}
                 />
                 {fieldErrors.firstName?.[0] ? (
                   <span className="mt-2 block text-sm font-bold text-[#e6392e]">
@@ -212,21 +252,21 @@ export function EventUpdatesModal() {
               </label>
 
               <label className="block">
-                <span className="mb-2 block text-sm font-black uppercase text-[#102344]">
+                <span className="mb-1.5 block text-xs font-black uppercase text-[#102344] sm:mb-2 sm:text-sm">
                   Last name
                 </span>
                 <input
                   type="text"
                   name="lastName"
                   value={formValues.lastName}
-                  onChange={(event) =>
-                    setFormValues((current) => ({
-                      ...current,
-                      lastName: event.target.value,
-                    }))
+                  onChange={(event) => updateFormValue("lastName", event.target.value)}
+                  onInput={(event) =>
+                    updateFormValue("lastName", event.currentTarget.value)
                   }
-                  className="w-full border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-base font-semibold text-[#102344] shadow-[5px_5px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white"
+                  className="w-full border-4 border-[#102344] bg-[#fff7e6] px-3 py-2.5 text-base font-semibold text-[#102344] shadow-[4px_4px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white sm:px-4 sm:py-3 sm:shadow-[5px_5px_0_#102344]"
                   autoComplete="family-name"
+                  required
+                  aria-invalid={Boolean(fieldErrors.lastName?.[0])}
                 />
                 {fieldErrors.lastName?.[0] ? (
                   <span className="mt-2 block text-sm font-bold text-[#e6392e]">
@@ -237,21 +277,20 @@ export function EventUpdatesModal() {
             </div>
 
             <label className="block">
-              <span className="mb-2 block text-sm font-black uppercase text-[#102344]">
+              <span className="mb-1.5 block text-xs font-black uppercase text-[#102344] sm:mb-2 sm:text-sm">
                 Email
               </span>
               <input
                 type="email"
                 name="email"
                 value={formValues.email}
-                onChange={(event) =>
-                  setFormValues((current) => ({
-                    ...current,
-                    email: event.target.value,
-                  }))
-                }
-                className="w-full border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-base font-semibold text-[#102344] shadow-[5px_5px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white"
+                onChange={(event) => updateFormValue("email", event.target.value)}
+                onInput={(event) => updateFormValue("email", event.currentTarget.value)}
+                className="w-full border-4 border-[#102344] bg-[#fff7e6] px-3 py-2.5 text-base font-semibold text-[#102344] shadow-[4px_4px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white sm:px-4 sm:py-3 sm:shadow-[5px_5px_0_#102344]"
                 autoComplete="email"
+                inputMode="email"
+                required
+                aria-invalid={Boolean(fieldErrors.email?.[0])}
               />
               {fieldErrors.email?.[0] ? (
                 <span className="mt-2 block text-sm font-bold text-[#e6392e]">
@@ -261,20 +300,20 @@ export function EventUpdatesModal() {
             </label>
 
             {requestError ? (
-              <p className="border-4 border-[#102344] bg-[#fff7e6] px-4 py-3 text-sm font-bold text-[#e6392e] shadow-[5px_5px_0_#102344]">
+              <p className="border-4 border-[#102344] bg-[#fff7e6] px-3 py-2.5 text-sm font-bold text-[#e6392e] shadow-[4px_4px_0_#102344] sm:px-4 sm:py-3 sm:shadow-[5px_5px_0_#102344]">
                 {requestError}
               </p>
             ) : null}
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="max-w-xl text-sm font-semibold leading-6 text-[#344760]">
+              <p className="max-w-xl text-xs font-semibold leading-5 text-[#344760] sm:text-sm sm:leading-6">
                 Sign up once and stay in the loop for ticket on-sale announcements and
                 key event updates.
               </p>
               <Button
                 type="submit"
                 disabled={isSubmitting}
-                className="h-auto rounded-none border-4 border-[#102344] bg-[#e6392e] px-6 py-3 text-sm font-black uppercase text-white shadow-[5px_5px_0_#102344] hover:bg-[#cf2f24] disabled:translate-y-0 disabled:opacity-100"
+                className="h-auto w-full rounded-none border-4 border-[#102344] bg-[#e6392e] px-6 py-3 text-sm font-black uppercase text-white shadow-[5px_5px_0_#102344] hover:bg-[#cf2f24] disabled:translate-y-0 disabled:opacity-100 sm:w-auto"
               >
                 {isSubmitting ? "Saving..." : "Get announcements"}
               </Button>

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,44 @@
+# Notification Flows
+
+## Overview
+
+Bubelpalooza uses Resend for transactional email sent by the application.
+
+Notification provider credentials belong in local `.env.local` files and hosted environment variable stores. Real API keys, subscriber lists, exports, message logs, and provider payloads must not be committed to the repository.
+
+## Event Updates Welcome Email
+
+The event updates signup endpoint stores a valid signup before attempting email delivery. A newly created signup triggers one welcome email through a hosted Resend template. A duplicate signup reuses the existing subscription record and does not send another welcome email.
+
+The actual welcome email subject, HTML, text fallback, and visual design live in Resend rather than in this public repository. Keep the template highly branded and guest-facing, following the durable event direction in `docs/theme.md`: yellow-forward, bold, poster/flyer inspired, and celebratory of crawfish, the pool, live music, merch, and community together.
+
+Template IDs are provider identifiers, not secrets. Keep them in the committed registry at `lib/notifications/resend-templates.ts` so adding future templates does not require a new environment variable per email flow.
+
+The application sends the registry template ID and this variable contract:
+
+- `GUEST_FIRST_NAME`: subscriber first name for greeting and light personalization. The application strips characters that could be interpreted as HTML markup before sending this value to Resend.
+
+Do not commit finished email HTML, copied provider templates, subscriber examples, message screenshots, or provider exports to the repository. For reviews, use Resend previews, provider test sends, or private screenshots stored outside the repo.
+
+## Required Environment Variables
+
+- `RESEND_API_KEY`: Resend API key used by the server-side send path.
+- `RESEND_FROM_EMAIL`: Verified sender email address configured for Resend. A friendly sender format such as `Bubelpalooza <hello@updates.bubelpalooza.com>` is supported.
+
+These values are read only on the server. Use `.env.local` for local development and Vercel environment variables for preview and production deployments.
+
+The application validates `RESEND_API_KEY` and `RESEND_FROM_EMAIL` during server environment startup, so production builds fail clearly if either value is not configured. A committed hosted template ID is required for the welcome email send attempt; if it is missing, signup capture still succeeds and the email path is skipped with a coarse operational warning.
+
+## Failure Behavior
+
+Signup persistence remains the primary path. If the hosted template ID is missing, Resend is unavailable, Resend is rate limited, or Resend returns an error, the application keeps the saved signup and returns the normal signup success response to the browser.
+
+Missing Resend provider credentials are treated as invalid application configuration and fail fast during server environment startup.
+
+Email failures are logged as coarse operational warnings without raw subscriber names, email addresses, request payloads, or provider response bodies.
+
+## Subscriber Data Handling
+
+Subscriber first name, last name, email address, source, and subscription status are stored in the application database for legitimate operational messaging use.
+
+Public responses should return only the minimum status needed by the browser. Subscriber data should not be exposed through client-side code, fixtures, screenshots, public logs, or casual developer-facing surfaces.

--- a/lib/env/public.ts
+++ b/lib/env/public.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { formatEnvErrors, optionalSecret, optionalUrl } from "@/lib/env/shared";
+import { envSecretValue, envUrlValue, formatEnvErrors } from "@/lib/env/shared";
 
 const publicEnvSchema = z.object({
-  NEXT_PUBLIC_APP_URL: optionalUrl,
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: optionalSecret,
-  NEXT_PUBLIC_SENTRY_DSN: optionalUrl,
+  NEXT_PUBLIC_APP_URL: envUrlValue,
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: envSecretValue,
+  NEXT_PUBLIC_SENTRY_DSN: envUrlValue,
 });
 
 const publicEnvResult = publicEnvSchema.safeParse({

--- a/lib/env/server.ts
+++ b/lib/env/server.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import {
+  emptyStringAsUndefined,
+  envDomainValue,
+  envPhoneNumberValue,
+  envSecretValue,
+  envSenderEmailValue,
+  envUrlValue,
   envUrl,
   formatEnvErrors,
-  optionalDomain,
-  optionalEmail,
-  optionalEnv,
-  optionalPhoneNumber,
-  optionalSecret,
-  optionalUrl,
   toHttpsUrl,
 } from "@/lib/env/shared";
 import { publicEnv } from "@/lib/env/public";
@@ -15,22 +15,22 @@ import { publicEnv } from "@/lib/env/public";
 const serverEnvSchema = z
   .object({
     NODE_ENV: z.enum(["development", "test", "production"]),
-    DATABASE_URL: optionalUrl,
-    DATABASE_URL_UNPOOLED: optionalUrl,
-    STRIPE_SECRET_KEY: optionalSecret,
-    STRIPE_WEBHOOK_SECRET: optionalSecret,
-    RESEND_API_KEY: optionalSecret,
-    RESEND_FROM_EMAIL: optionalEmail,
-    TWILIO_ACCOUNT_SID: optionalSecret,
-    TWILIO_AUTH_TOKEN: optionalSecret,
-    TWILIO_PHONE_NUMBER: optionalPhoneNumber,
-    SENTRY_DSN: optionalUrl,
-    SENTRY_AUTH_TOKEN: optionalSecret,
-    VERCEL_ENV: optionalEnv(z.enum(["production", "preview", "development"])),
-    VERCEL_TARGET_ENV: optionalSecret,
-    VERCEL_URL: optionalDomain,
-    VERCEL_BRANCH_URL: optionalDomain,
-    VERCEL_PROJECT_PRODUCTION_URL: optionalDomain,
+    DATABASE_URL: envUrlValue,
+    DATABASE_URL_UNPOOLED: envUrlValue,
+    STRIPE_SECRET_KEY: envSecretValue,
+    STRIPE_WEBHOOK_SECRET: envSecretValue,
+    RESEND_API_KEY: envSecretValue,
+    RESEND_FROM_EMAIL: envSenderEmailValue,
+    TWILIO_ACCOUNT_SID: envSecretValue,
+    TWILIO_AUTH_TOKEN: envSecretValue,
+    TWILIO_PHONE_NUMBER: envPhoneNumberValue,
+    SENTRY_DSN: envUrlValue,
+    SENTRY_AUTH_TOKEN: envSecretValue,
+    VERCEL_ENV: emptyStringAsUndefined(z.enum(["production", "preview", "development"])),
+    VERCEL_TARGET_ENV: envSecretValue,
+    VERCEL_URL: envDomainValue,
+    VERCEL_BRANCH_URL: envDomainValue,
+    VERCEL_PROJECT_PRODUCTION_URL: envDomainValue,
   })
   .superRefine((env, context) => {
     if (!env.DATABASE_URL && !env.DATABASE_URL_UNPOOLED) {
@@ -38,6 +38,22 @@ const serverEnvSchema = z
         code: z.ZodIssueCode.custom,
         path: ["DATABASE_URL"],
         message: "or DATABASE_URL_UNPOOLED is required",
+      });
+    }
+
+    if (!env.RESEND_API_KEY) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["RESEND_API_KEY"],
+        message: "is required for server email delivery",
+      });
+    }
+
+    if (!env.RESEND_FROM_EMAIL) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["RESEND_FROM_EMAIL"],
+        message: "is required for server email delivery",
       });
     }
   });

--- a/lib/env/shared.ts
+++ b/lib/env/shared.ts
@@ -12,7 +12,7 @@ const validUrl = (value: string) => {
   }
 };
 
-export const optionalEnv = <T extends z.ZodType>(schema: T) =>
+export const emptyStringAsUndefined = <T extends z.ZodType>(schema: T) =>
   z.preprocess(emptyStringToUndefined, schema.optional());
 
 export const envUrl = z
@@ -21,20 +21,43 @@ export const envUrl = z
   .min(1, "is required")
   .refine(validUrl, "must be a valid URL");
 
-export const optionalUrl = optionalEnv(envUrl);
+export const envUrlValue = emptyStringAsUndefined(envUrl);
 
-export const optionalEmail = optionalEnv(z.string().trim().email("must be a valid email address"));
+export const envEmailValue = emptyStringAsUndefined(
+  z.string().trim().email("must be a valid email address"),
+);
 
-export const optionalPhoneNumber = optionalEnv(
+const emailAddress = z.string().trim().email();
+
+function extractSenderEmailAddress(value: string) {
+  const senderMatch = value.trim().match(/^.+<([^<>]+)>$/);
+
+  return senderMatch ? senderMatch[1].trim() : value.trim();
+}
+
+export const envSenderEmailValue = emptyStringAsUndefined(
+  z
+    .string()
+    .trim()
+    .min(1, "cannot be empty")
+    .refine(
+      (value) => emailAddress.safeParse(extractSenderEmailAddress(value)).success,
+      "must be a valid email address or sender format like Name <email@example.com>",
+    ),
+);
+
+export const envPhoneNumberValue = emptyStringAsUndefined(
   z
     .string()
     .trim()
     .regex(/^\+[1-9]\d{1,14}$/, "must be a valid E.164 phone number"),
 );
 
-export const optionalSecret = optionalEnv(z.string().trim().min(1, "cannot be empty"));
+export const envSecretValue = emptyStringAsUndefined(
+  z.string().trim().min(1, "cannot be empty"),
+);
 
-export const optionalDomain = optionalEnv(
+export const envDomainValue = emptyStringAsUndefined(
   z
     .string()
     .trim()

--- a/lib/event-updates/constants.ts
+++ b/lib/event-updates/constants.ts
@@ -1,6 +1,5 @@
 export const EVENT_UPDATES_STORAGE_KEYS = {
   dismissedAt: "bubelpalooza-event-updates-dismissed-at",
-  submittedAt: "bubelpalooza-event-updates-submitted-at",
 } as const;
 
 export const EVENT_UPDATES_MODAL_EVENT = "bubelpalooza:event-updates:open";

--- a/lib/event-updates/email.ts
+++ b/lib/event-updates/email.ts
@@ -1,0 +1,65 @@
+import { Resend } from "resend";
+import type { EventUpdateSignup } from "@/lib/db/schema";
+import { serverEnv } from "@/lib/env/server";
+import { resendTemplateIds } from "@/lib/notifications/resend-templates";
+
+type WelcomeEmailResult =
+  | { status: "sent"; emailId: string }
+  | { status: "skipped"; reason: "missing-configuration" }
+  | { status: "failed"; reason: "provider-error" };
+
+let resendClient: Resend | null = null;
+
+function getResendClient() {
+  if (!serverEnv.RESEND_API_KEY) {
+    return null;
+  }
+
+  resendClient ??= new Resend(serverEnv.RESEND_API_KEY);
+
+  return resendClient;
+}
+
+function sanitizeTemplateVariable(value: string) {
+  return value.replace(/[<>&]/g, "").trim() || "friend";
+}
+
+export async function sendEventUpdateWelcomeEmail(
+  signup: Pick<EventUpdateSignup, "firstName" | "email">,
+): Promise<WelcomeEmailResult> {
+  const resend = getResendClient();
+  const templateId = resendTemplateIds.eventUpdatesWelcome;
+
+  if (!resend || !serverEnv.RESEND_FROM_EMAIL || !templateId) {
+    return { status: "skipped", reason: "missing-configuration" };
+  }
+
+  const response = await resend.emails
+    .send({
+      from: serverEnv.RESEND_FROM_EMAIL,
+      to: signup.email,
+      template: {
+        id: templateId,
+        variables: {
+          GUEST_FIRST_NAME: sanitizeTemplateVariable(signup.firstName),
+        },
+      },
+      tags: [
+        {
+          name: "flow",
+          value: "event_updates_welcome",
+        },
+      ],
+    })
+    .catch(() => null);
+
+  if (!response) {
+    return { status: "failed", reason: "provider-error" };
+  }
+
+  if (response.error) {
+    return { status: "failed", reason: "provider-error" };
+  }
+
+  return { status: "sent", emailId: response.data.id };
+}

--- a/lib/notifications/resend-templates.ts
+++ b/lib/notifications/resend-templates.ts
@@ -1,0 +1,5 @@
+export const resendTemplateIds = {
+  eventUpdatesWelcome: "9cc141fc-deba-49bb-895b-c2913c9c5e28",
+} as const satisfies Record<string, string | null>;
+
+export type ResendTemplateName = keyof typeof resendTemplateIds;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "resend": "^6.12.3",
         "shadcn": "^4.5.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -4220,6 +4221,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -7276,6 +7283,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -9906,6 +9919,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -10340,6 +10359,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -10938,6 +10978,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11216,6 +11266,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/tagged-tag": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "resend": "^6.12.3",
     "shadcn": "^4.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
## Summary

- Send the event updates welcome email through Resend when a signup is newly created.
- Add the committed Resend template registry, email send helper, and notification docs.
- Tighten Resend sender env validation and document required hosted configuration.
- Refine the signup modal success copy, mobile centering, and refresh behavior so duplicate protection stays server-side.

## Linked Issue

Closes #46

## Testing

- `npm run lint`
- `npm run build`
- Checked the update signup modal at mobile, tablet, and desktop viewport sizes with Playwright screenshots.
- Published the hosted Resend welcome template and verified the template status in Resend.

## Notes

- Vercel preview and production need `RESEND_API_KEY` and `RESEND_FROM_EMAIL` configured before this merges; builds fail fast without them.
- Welcome email delivery only runs for newly created signup records. Duplicate signups reuse the existing record and skip another welcome email.