### PR TITLE
Add phone enrollment to event updates signup

### DIFF
--- a/components/event-updates-modal.tsx
+++ b/components/event-updates-modal.tsx
@@ -10,17 +10,22 @@ import {
   EVENT_UPDATES_STORAGE_KEYS,
 } from "@/lib/event-updates/constants";
 
-type FieldErrors = Partial<Record<"firstName" | "lastName" | "email", string[]>>;
+type FieldErrors = Partial<
+  Record<"firstName" | "lastName" | "email" | "phoneNumber" | "smsOptIn", string[]>
+>;
 
 const initialFormState = {
   firstName: "",
   lastName: "",
   email: "",
+  phoneNumber: "",
+  smsOptIn: false,
 };
 
 type FormField = keyof typeof initialFormState;
+type TextFormField = Exclude<FormField, "smsOptIn">;
 
-function getFormString(formData: FormData, field: FormField) {
+function getFormString(formData: FormData, field: TextFormField) {
   const value = formData.get(field);
 
   return typeof value === "string" ? value : "";
@@ -101,7 +106,7 @@ export function EventUpdatesModal() {
     );
   }
 
-  function updateFormValue(field: FormField, value: string) {
+  function updateFormValue(field: TextFormField, value: string) {
     setFormValues((current) => ({
       ...current,
       [field]: value,
@@ -119,6 +124,24 @@ export function EventUpdatesModal() {
     }
   }
 
+  function updateSmsOptIn(value: boolean) {
+    setFormValues((current) => ({
+      ...current,
+      smsOptIn: value,
+    }));
+
+    if (fieldErrors.smsOptIn?.length) {
+      setFieldErrors((current) => ({
+        ...current,
+        smsOptIn: undefined,
+      }));
+    }
+
+    if (requestError) {
+      setRequestError(null);
+    }
+  }
+
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
@@ -126,6 +149,8 @@ export function EventUpdatesModal() {
       firstName: getFormString(formData, "firstName"),
       lastName: getFormString(formData, "lastName"),
       email: getFormString(formData, "email"),
+      phoneNumber: getFormString(formData, "phoneNumber"),
+      smsOptIn: formData.get("smsOptIn") === "on",
     };
 
     setIsSubmitting(true);
@@ -297,6 +322,55 @@ export function EventUpdatesModal() {
                   Email {fieldErrors.email[0]}
                 </span>
               ) : null}
+            </label>
+
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-black uppercase text-[#102344] sm:mb-2 sm:text-sm">
+                Phone <span className="normal-case">(optional)</span>
+              </span>
+              <input
+                type="tel"
+                name="phoneNumber"
+                value={formValues.phoneNumber}
+                onChange={(event) => updateFormValue("phoneNumber", event.target.value)}
+                onInput={(event) =>
+                  updateFormValue("phoneNumber", event.currentTarget.value)
+                }
+                className="w-full border-4 border-[#102344] bg-[#fff7e6] px-3 py-2.5 text-base font-semibold text-[#102344] shadow-[4px_4px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white sm:px-4 sm:py-3 sm:shadow-[5px_5px_0_#102344]"
+                autoComplete="tel"
+                inputMode="tel"
+                placeholder="(512) 555-0123"
+                aria-invalid={Boolean(fieldErrors.phoneNumber?.[0])}
+              />
+              {fieldErrors.phoneNumber?.[0] ? (
+                <span className="mt-2 block text-sm font-bold text-[#e6392e]">
+                  Phone {fieldErrors.phoneNumber[0]}
+                </span>
+              ) : null}
+            </label>
+
+            <label className="flex gap-3 border-4 border-[#102344] bg-[#fff7e6] p-3 shadow-[4px_4px_0_#102344] sm:p-4 sm:shadow-[5px_5px_0_#102344]">
+              <input
+                type="checkbox"
+                name="smsOptIn"
+                checked={formValues.smsOptIn}
+                onChange={(event) => updateSmsOptIn(event.target.checked)}
+                className="mt-1 h-5 w-5 shrink-0 cursor-pointer accent-[#e6392e]"
+                aria-invalid={Boolean(fieldErrors.smsOptIn?.[0])}
+              />
+              <span className="text-xs font-semibold leading-5 text-[#344760] sm:text-sm sm:leading-6">
+                <span className="block font-black uppercase text-[#102344]">
+                  Text me updates too
+                </span>
+                By checking this box, I agree that Bubelpalooza may send event
+                update texts to the number above. Message and data rates may apply.
+                Reply STOP to opt out.
+                {fieldErrors.smsOptIn?.[0] ? (
+                  <span className="mt-2 block font-bold text-[#e6392e]">
+                    Text opt-in {fieldErrors.smsOptIn[0]}
+                  </span>
+                ) : null}
+              </span>
             </label>
 
             {requestError ? (

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -37,8 +37,18 @@ Missing Resend provider credentials are treated as invalid application configura
 
 Email failures are logged as coarse operational warnings without raw subscriber names, email addresses, request payloads, or provider response bodies.
 
+## Event Updates SMS Enrollment
+
+The public updates signup form can also capture an optional phone number for guests who explicitly opt into text updates. Phone numbers are normalized to a US E.164-style value before storage. A phone number without SMS consent is rejected, and SMS consent without a phone number is rejected.
+
+SMS enrollment is captured as application data only in this implementation. The signup endpoint does not send text messages yet, so Twilio credentials are not required for this flow. Future SMS sending work should use the stored normalized phone number and consent metadata, and should stay isolated from the Resend welcome email path.
+
+Consent metadata stored with the signup includes the consent timestamp, the form source, and the consent copy version. When consent copy changes materially, update the committed consent copy version so future records remain reviewable.
+
+Duplicate email submissions reuse the existing signup record. If an existing email-only signup later submits a phone number with explicit SMS consent, the existing record is updated with the phone enrollment details. A phone number already attached to another signup is not attached again.
+
 ## Subscriber Data Handling
 
-Subscriber first name, last name, email address, source, and subscription status are stored in the application database for legitimate operational messaging use.
+Subscriber first name, last name, email address, optional phone number, consent metadata, source, and subscription status are stored in the application database for legitimate operational messaging use.
 
 Public responses should return only the minimum status needed by the browser. Subscriber data should not be exposed through client-side code, fixtures, screenshots, public logs, or casual developer-facing surfaces.

--- a/drizzle/0001_elite_ultragirl.sql
+++ b/drizzle/0001_elite_ultragirl.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "event_update_signups" ADD COLUMN "phone_number" text;--> statement-breakpoint
+ALTER TABLE "event_update_signups" ADD COLUMN "sms_consent_status" text DEFAULT 'not_subscribed' NOT NULL;--> statement-breakpoint
+ALTER TABLE "event_update_signups" ADD COLUMN "sms_consent_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "event_update_signups" ADD COLUMN "sms_consent_source" text;--> statement-breakpoint
+ALTER TABLE "event_update_signups" ADD COLUMN "sms_consent_copy_version" text;--> statement-breakpoint
+ALTER TABLE "event_update_signups" ADD CONSTRAINT "event_update_signups_phone_number_unique" UNIQUE("phone_number");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,130 @@
+{
+  "id": "521fab74-bea3-4aac-afde-f366d00409d5",
+  "prevId": "6714a74f-58f0-4738-9855-ba627f7cbe57",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.event_update_signups": {
+      "name": "event_update_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "sms_consent_status": {
+          "name": "sms_consent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_subscribed'"
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_copy_version": {
+          "name": "sms_consent_copy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_update_signups_email_unique": {
+          "name": "event_update_signups_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "event_update_signups_phone_number_unique": {
+          "name": "event_update_signups_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778113556900,
       "tag": "0000_deep_quasar",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1778264885171,
+      "tag": "0001_elite_ultragirl",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -5,8 +5,13 @@ export const eventUpdateSignups = pgTable("event_update_signups", {
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   email: text("email").notNull().unique(),
+  phoneNumber: text("phone_number").unique(),
   source: text("source").notNull(),
   status: text("status").notNull().default("subscribed"),
+  smsConsentStatus: text("sms_consent_status").notNull().default("not_subscribed"),
+  smsConsentAt: timestamp("sms_consent_at", { withTimezone: true }),
+  smsConsentSource: text("sms_consent_source"),
+  smsConsentCopyVersion: text("sms_consent_copy_version"),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });

--- a/lib/event-updates/constants.ts
+++ b/lib/event-updates/constants.ts
@@ -5,3 +5,5 @@ export const EVENT_UPDATES_STORAGE_KEYS = {
 export const EVENT_UPDATES_MODAL_EVENT = "bubelpalooza:event-updates:open";
 export const EVENT_UPDATES_DISMISS_DAYS = 14;
 export const EVENT_UPDATES_AUTO_OPEN_DELAY_MS = 4500;
+export const EVENT_UPDATES_SMS_CONSENT_COPY_VERSION =
+  "event-updates-sms-consent-v1";

--- a/lib/event-updates/schema.ts
+++ b/lib/event-updates/schema.ts
@@ -6,11 +6,65 @@ const nameSchema = z
   .min(1, "is required")
   .max(80, "must be 80 characters or fewer");
 
+const usPhoneNumberPattern = /^\+1[2-9]\d{2}[2-9]\d{6}$/;
+
+function normalizeUsPhoneNumber(value: string) {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  const digits = trimmedValue.replace(/\D/g, "");
+
+  if (digits.length === 10) {
+    return `+1${digits}`;
+  }
+
+  if (digits.length === 11 && digits.startsWith("1")) {
+    return `+${digits}`;
+  }
+
+  return trimmedValue;
+}
+
+const optionalPhoneNumberSchema = z.preprocess(
+  (value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    return normalizeUsPhoneNumber(value);
+  },
+  z
+    .string()
+    .regex(usPhoneNumberPattern, "must be a valid US phone number")
+    .optional(),
+);
+
 export const eventUpdateSignupSchema = z.object({
   firstName: nameSchema,
   lastName: nameSchema,
   email: z.string().trim().min(1, "is required").email("must be a valid email address"),
+  phoneNumber: optionalPhoneNumberSchema,
+  smsOptIn: z.boolean().optional().default(false),
   source: z.string().trim().min(1).max(50),
+}).superRefine((signup, context) => {
+  if (signup.phoneNumber && !signup.smsOptIn) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["smsOptIn"],
+      message: "is required to receive text updates",
+    });
+  }
+
+  if (!signup.phoneNumber && signup.smsOptIn) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["phoneNumber"],
+      message: "is required to receive text updates",
+    });
+  }
 });
 
 export type EventUpdateSignupInput = z.infer<typeof eventUpdateSignupSchema>;

--- a/lib/event-updates/service.ts
+++ b/lib/event-updates/service.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { getDb } from "@/lib/db";
 import { eventUpdateSignups } from "@/lib/db/schema";
+import { EVENT_UPDATES_SMS_CONSENT_COPY_VERSION } from "@/lib/event-updates/constants";
 import {
   type EventUpdateSignupInput,
   eventUpdateSignupSchema,
@@ -11,20 +12,79 @@ function normalizeSignup(input: EventUpdateSignupInput) {
     firstName: input.firstName.trim(),
     lastName: input.lastName.trim(),
     email: input.email.trim().toLowerCase(),
+    phoneNumber: input.phoneNumber,
+    smsOptIn: input.smsOptIn,
     source: input.source.trim(),
   };
+}
+
+function getSmsConsentValues(
+  signup: ReturnType<typeof normalizeSignup>,
+  consentedAt: Date,
+) {
+  if (!signup.phoneNumber || !signup.smsOptIn) {
+    return {};
+  }
+
+  return {
+    phoneNumber: signup.phoneNumber,
+    smsConsentStatus: "subscribed",
+    smsConsentAt: consentedAt,
+    smsConsentSource: signup.source,
+    smsConsentCopyVersion: EVENT_UPDATES_SMS_CONSENT_COPY_VERSION,
+  };
+}
+
+function canUpdateSmsConsent(
+  existingSignup: typeof eventUpdateSignups.$inferSelect,
+  phoneNumber: string,
+) {
+  return (
+    existingSignup.phoneNumber !== phoneNumber ||
+    existingSignup.smsConsentStatus !== "subscribed" ||
+    !existingSignup.smsConsentAt ||
+    existingSignup.smsConsentCopyVersion !== EVENT_UPDATES_SMS_CONSENT_COPY_VERSION
+  );
 }
 
 export async function saveEventUpdateSignup(input: EventUpdateSignupInput) {
   const parsed = eventUpdateSignupSchema.parse(input);
   const signup = normalizeSignup(parsed);
   const db = getDb();
+  const consentedAt = new Date();
 
   const existingSignup = await db.query.eventUpdateSignups.findFirst({
     where: eq(eventUpdateSignups.email, signup.email),
   });
 
+  const existingPhoneSignup = signup.phoneNumber
+    ? await db.query.eventUpdateSignups.findFirst({
+        where: eq(eventUpdateSignups.phoneNumber, signup.phoneNumber),
+      })
+    : null;
+
   if (existingSignup) {
+    if (
+      signup.phoneNumber &&
+      signup.smsOptIn &&
+      (!existingPhoneSignup || existingPhoneSignup.id === existingSignup.id) &&
+      canUpdateSmsConsent(existingSignup, signup.phoneNumber)
+    ) {
+      const [updatedSignup] = await db
+        .update(eventUpdateSignups)
+        .set({
+          ...getSmsConsentValues(signup, consentedAt),
+          updatedAt: consentedAt,
+        })
+        .where(eq(eventUpdateSignups.id, existingSignup.id))
+        .returning();
+
+      return {
+        status: "updated" as const,
+        signup: updatedSignup,
+      };
+    }
+
     return {
       status: "duplicate" as const,
       signup: existingSignup,
@@ -34,8 +94,12 @@ export async function saveEventUpdateSignup(input: EventUpdateSignupInput) {
   const [createdSignup] = await db
     .insert(eventUpdateSignups)
     .values({
-      ...signup,
+      firstName: signup.firstName,
+      lastName: signup.lastName,
+      email: signup.email,
+      source: signup.source,
       status: "subscribed",
+      ...(!existingPhoneSignup ? getSmsConsentValues(signup, consentedAt) : {}),
     })
     .returning();
 


### PR DESCRIPTION
## Summary
- Add optional phone number capture and explicit SMS opt-in language to the event updates modal.
- Normalize US phone numbers server-side, reject phone-without-consent and consent-without-phone submissions, and store consent metadata with a durable copy version.
- Add nullable SMS enrollment fields and a Drizzle migration while keeping the existing Resend welcome email behavior unchanged.
- Document the SMS enrollment behavior as capture-only; no text messages are sent in this pass.

## Linked Issue
Closes #41

## Testing
- `npm run db:generate`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Playwright screenshots of the updates modal at mobile, tablet, and desktop viewport sizes.
- API smoke checks confirmed invalid phone input and phone-without-consent submissions return `400` before persistence.

## Notes
- This PR does not send SMS messages and does not require Twilio credentials for the signup flow.
- If an existing email-only signup later submits a valid phone number with explicit SMS consent, the existing signup record is updated instead of creating a second row.