### PR TITLE
Build merch-first ticket package wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ NODE_ENV="development"
 STRIPE_SECRET_KEY="sk_test_your_value_here"
 STRIPE_WEBHOOK_SECRET="whsec_your_value_here"
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_your_value_here"
+# Keep false in production until order persistence and webhooks are ready.
+NEXT_PUBLIC_TICKETS_CHECKOUT_ENABLED="false"
 
 # Resend
 RESEND_API_KEY="re_your_value_here"

--- a/app/api/tickets/checkout/route.ts
+++ b/app/api/tickets/checkout/route.ts
@@ -1,0 +1,220 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { MERCH_ASSETS } from "@/lib/merch/catalog";
+import {
+  describePassSelection,
+  getCartTotals,
+  getPassPriceCents,
+  getTicketPackage,
+  ticketCartSchema,
+  type TicketCart,
+  type TicketCartPass,
+} from "@/lib/tickets/cart";
+import { serverEnv } from "@/lib/env/server";
+
+export const runtime = "nodejs";
+
+const stripe = serverEnv.STRIPE_SECRET_KEY
+  ? new Stripe(serverEnv.STRIPE_SECRET_KEY)
+  : null;
+const isCheckoutEnabled =
+  process.env.NEXT_PUBLIC_TICKETS_CHECKOUT_ENABLED === "true";
+
+type CheckoutSessionCreateParams = NonNullable<
+  Parameters<NonNullable<typeof stripe>["checkout"]["sessions"]["create"]>[0]
+>;
+type CheckoutLineItem = NonNullable<
+  CheckoutSessionCreateParams["line_items"]
+>[number];
+type CheckoutBrandingSettings = CheckoutSessionCreateParams["branding_settings"];
+
+function getPublicAssetUrl(path: string) {
+  const url = new URL(path, serverEnv.APP_URL);
+
+  return url.protocol === "https:" ? url.toString() : undefined;
+}
+
+function getCheckoutBrandingSettings(): CheckoutBrandingSettings {
+  const iconUrl = getPublicAssetUrl("/icon.png");
+
+  return {
+    display_name: "Bubelpalooza",
+    background_color: "#FFF1C7",
+    button_color: "#E6392E",
+    border_style: "rectangular",
+    font_family: "inter",
+    icon: iconUrl
+      ? {
+          type: "url",
+          url: iconUrl,
+        }
+      : undefined,
+  };
+}
+
+function getPackageImagePath(packageId: TicketCartPass["packageId"]) {
+  if (packageId === "complete") {
+    return MERCH_ASSETS.lineupCutout;
+  }
+
+  if (packageId === "koozie") {
+    return MERCH_ASSETS.standardShortKoozie;
+  }
+
+  if (packageId === "sticker") {
+    return MERCH_ASSETS.sticker;
+  }
+
+  return undefined;
+}
+
+function createLineItem(
+  name: string,
+  unitAmount: number,
+  description?: string,
+  imagePath?: string,
+): CheckoutLineItem {
+  const imageUrl = imagePath ? getPublicAssetUrl(imagePath) : undefined;
+
+  return {
+    quantity: 1,
+    price_data: {
+      currency: "usd",
+      unit_amount: unitAmount,
+      product_data: {
+        name,
+        description,
+        images: imageUrl ? [imageUrl] : undefined,
+      },
+    },
+  };
+}
+
+function createPassLineItem(
+  pass: TicketCartPass,
+  passIndex: number,
+): CheckoutLineItem {
+  const selectedPackage = getTicketPackage(pass.packageId);
+
+  return createLineItem(
+    `Pass ${passIndex + 1}: ${selectedPackage.name}`,
+    getPassPriceCents(pass),
+    describePassSelection(pass),
+    getPackageImagePath(pass.packageId),
+  );
+}
+
+function createCheckoutLineItems(cart: TicketCart) {
+  const lineItems = cart.passes.map(createPassLineItem);
+
+  if (cart.donationCents > 0) {
+    lineItems.push(
+      createLineItem(
+        "Bubelpalooza extra donation",
+        cart.donationCents,
+        "Order-level donation added once to the full order.",
+      ),
+    );
+  }
+
+  return lineItems;
+}
+
+export async function POST(request: Request) {
+  if (!isCheckoutEnabled) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message:
+          "Tickets open soon. You can choose your packages now and come back shortly to buy.",
+      },
+      { status: 503 },
+    );
+  }
+
+  if (!stripe) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message:
+          "Checkout is not available right now. Please check back soon.",
+      },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        message: "Please check the order and try again.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsedCart = ticketCartSchema.safeParse(body);
+
+  if (!parsedCart.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message: "Please finish the required pass choices before checkout.",
+        fieldErrors: parsedCart.error.flatten().fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  const cart = parsedCart.data;
+  const totals = getCartTotals(cart);
+
+  try {
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "payment",
+      branding_settings: getCheckoutBrandingSettings(),
+      custom_text: {
+        submit: {
+          message:
+            "Bubelpalooza merch is picked up at check-in on event day.",
+        },
+      },
+      line_items: createCheckoutLineItems(cart),
+      success_url: `${serverEnv.APP_URL}/tickets/success`,
+      cancel_url: `${serverEnv.APP_URL}/tickets`,
+      client_reference_id: crypto.randomUUID(),
+      metadata: {
+        source: "tickets_wizard",
+        pass_count: String(cart.passes.length),
+        donation_cents: String(cart.donationCents),
+        total_cents: String(totals.totalCents),
+      },
+    });
+
+    if (!checkoutSession.url) {
+      throw new Error("Stripe Checkout session did not return a URL.");
+    }
+
+    return NextResponse.json({
+      ok: true,
+      url: checkoutSession.url,
+    });
+  } catch (error) {
+    console.error(
+      "Failed to create package Checkout session.",
+      error instanceof Error ? { name: error.name } : undefined,
+    );
+
+    return NextResponse.json(
+      {
+        ok: false,
+        message: "Checkout is not available right now. Please try again soon.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/merch/page.tsx
+++ b/app/merch/page.tsx
@@ -7,7 +7,7 @@ import { MERCH_ASSETS, ticketPackages } from "@/lib/merch/catalog";
 export const metadata: Metadata = {
   title: "Merch",
   description:
-    "Preview the $25 Bubelpalooza complete package with entry, boil, shirt, koozie, and sticker.",
+    "Preview the $25 Bubelpalooza ultimate package with entry, boil, shirt, koozie, and sticker.",
 };
 
 function getCompletePackage() {
@@ -16,7 +16,7 @@ function getCompletePackage() {
   );
 
   if (!packageDetails) {
-    throw new Error("Complete package is missing from the merch catalog.");
+    throw new Error("Ultimate package is missing from the merch catalog.");
   }
 
   return packageDetails;
@@ -67,7 +67,7 @@ export default function MerchPage() {
                 size="lg"
                 className="h-auto w-full rounded-none border-4 border-[#102344] bg-[#fff1c7] px-7 py-4 text-base font-black uppercase text-[#102344] shadow-[6px_6px_0_#102344] hover:bg-[#fff7e6] sm:w-auto"
               >
-                <Link href="/#tickets">Event passes</Link>
+                <Link href="/tickets">Build passes</Link>
               </Button>
             </div>
           </div>
@@ -77,7 +77,7 @@ export default function MerchPage() {
             <div className="absolute -bottom-4 left-4 h-20 w-48 bg-[#102344] sm:h-28 sm:w-72" />
             <Image
               src={MERCH_ASSETS.lineupCutout}
-              alt="Bubelpalooza complete package merch with event shirts, koozies, and sticker."
+              alt="Bubelpalooza ultimate package merch with event shirts, koozies, and sticker."
               width={1448}
               height={1086}
               priority
@@ -116,7 +116,7 @@ export default function MerchPage() {
             <div className="grid gap-5 sm:grid-cols-[1fr_auto] sm:items-start">
               <div>
                 <p className="inline-block bg-[#ffd447] px-3 py-1 text-xs font-black uppercase text-[#102344]">
-                  Complete package
+                  Ultimate package
                 </p>
                 <h3
                   data-poster="true"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,7 @@ const scheduleItems = [
 const ticketNotes = [
   {
     label: "Best deal",
-    title: "$25 complete package",
+    title: "$25 ultimate package",
     copy: "Entry, boil, shirt, koozie, and sticker in one easy pick.",
   },
   {
@@ -53,7 +53,7 @@ function getCompletePackage() {
   );
 
   if (!packageDetails) {
-    throw new Error("Complete package is missing from the merch catalog.");
+    throw new Error("Ultimate package is missing from the merch catalog.");
   }
 
   return packageDetails;
@@ -121,9 +121,7 @@ export default function Home() {
                 size="lg"
                 className="h-auto rounded-none border-4 border-[#102344] bg-[#e6392e] px-7 py-4 text-base font-black uppercase text-white shadow-[6px_6px_0_#102344] hover:bg-[#cf2f24]"
               >
-                <a href="#complete-package">
-                  {completePackage.priceLabel} package
-                </a>
+                <Link href="/tickets">Buy tickets</Link>
               </Button>
               <Button
                 asChild
@@ -220,7 +218,7 @@ export default function Home() {
                 size="lg"
                 className="h-auto rounded-none border-4 border-[#102344] bg-[#e6392e] px-7 py-4 text-base font-black uppercase text-white shadow-[6px_6px_0_#102344] hover:bg-[#cf2f24]"
               >
-                <Link href="/merch">Preview the package</Link>
+                <Link href="/tickets">Build your package</Link>
               </Button>
               <Button
                 asChild
@@ -237,7 +235,7 @@ export default function Home() {
             <div className="absolute -bottom-3 left-4 h-20 w-48 bg-[#102344] sm:h-28 sm:w-72" />
             <Image
               src={MERCH_ASSETS.lineupCutout}
-              alt="Bubelpalooza complete package merch with event shirts, koozies, and sticker."
+              alt="Bubelpalooza ultimate package merch with event shirts, koozies, and sticker."
               width={1448}
               height={1086}
               sizes="(min-width: 1024px) 55vw, 100vw"
@@ -364,7 +362,7 @@ export default function Home() {
             </div>
             <div className="max-w-2xl border-t-8 border-[#2ec4f3] pt-5">
               <p className="text-lg font-semibold leading-8 text-[#344760]">
-                Start with the complete package. It is the cleanest way into
+                Start with the ultimate package. It is the cleanest way into
                 the full day: food, pool, live music, and the 2026 gear.
               </p>
               <Button
@@ -373,7 +371,7 @@ export default function Home() {
                 size="lg"
                 className="mt-5 h-auto rounded-none border-4 border-[#102344] bg-[#fff7e6] px-6 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-white"
               >
-                <Link href="/merch">Preview merch</Link>
+                <Link href="/tickets">Build passes</Link>
               </Button>
             </div>
           </div>

--- a/app/tickets/page.tsx
+++ b/app/tickets/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { TicketWizardLoader } from "@/app/tickets/ticket-wizard-loader";
+
+export const metadata: Metadata = {
+  title: "Tickets",
+  description:
+    "Build Bubelpalooza passes with package, shirt, koozie, sticker, and donation choices.",
+};
+
+export default function TicketsPage() {
+  return (
+    <div className="bg-[#ffd447] text-[#102344]">
+      <section className="border-b-[10px] border-[#102344] px-5 py-10 sm:px-8 sm:py-12 lg:px-10">
+        <div className="mx-auto max-w-7xl">
+          <div className="grid gap-6 lg:grid-cols-[0.92fr_1.08fr] lg:items-end">
+            <div>
+              <p className="inline-block border-4 border-[#102344] bg-[#2ec4f3] px-4 py-2 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344]">
+                Tickets + merch
+              </p>
+              <h1
+                data-poster="true"
+                className="mt-5 max-w-4xl text-[3.6rem] leading-[0.86] text-[#e6392e] min-[430px]:text-7xl sm:text-8xl"
+              >
+                BUILD YOUR BUBELPALOOZA PASS.
+              </h1>
+            </div>
+            <div className="border-l-8 border-[#e6392e] bg-[#fff7e6] p-5 text-[#102344] shadow-[8px_8px_0_#102344]">
+              <p className="text-lg font-black leading-8">
+                Start with the ultimate package for entry, food, shirt, koozie,
+                and sticker, or choose a lighter pass for each guest.
+              </p>
+              <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                <Button
+                  asChild
+                  variant="outline"
+                  className="h-auto rounded-none border-4 border-[#102344] bg-[#fff1c7] px-5 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-white"
+                >
+                  <Link href="/merch">Preview merch</Link>
+                </Button>
+                <Button
+                  asChild
+                  variant="outline"
+                  className="h-auto rounded-none border-4 border-[#102344] bg-[#ffd447] px-5 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-white"
+                >
+                  <Link href="/#day-schedule">See schedule</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-5 py-10 sm:px-8 sm:py-12 lg:px-10">
+        <div className="mx-auto max-w-7xl">
+          <TicketWizardLoader />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/tickets/success/clear-ticket-cart.tsx
+++ b/app/tickets/success/clear-ticket-cart.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+import { TICKET_CART_STORAGE_KEY } from "@/lib/tickets/cart";
+
+export function ClearTicketCart() {
+  useEffect(() => {
+    window.localStorage.removeItem(TICKET_CART_STORAGE_KEY);
+  }, []);
+
+  return null;
+}

--- a/app/tickets/success/page.tsx
+++ b/app/tickets/success/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ClearTicketCart } from "@/app/tickets/success/clear-ticket-cart";
+
+export const metadata: Metadata = {
+  title: "Order Received",
+  description:
+    "Bubelpalooza order confirmation page with next steps for event-day check-in.",
+};
+
+export default function TicketsSuccessPage() {
+  return (
+    <div className="bg-[#ffd447] px-5 py-12 text-[#102344] sm:px-8 sm:py-16 lg:px-10">
+      <ClearTicketCart />
+      <section className="mx-auto max-w-4xl border-4 border-[#102344] bg-[#fff7e6] p-6 shadow-[10px_10px_0_#102344] sm:p-8">
+        <p className="inline-flex items-center gap-2 bg-[#102344] px-4 py-2 text-sm font-black uppercase text-[#ffd447]">
+          <CheckCircle2 className="size-5" />
+          Order received
+        </p>
+        <h1
+          data-poster="true"
+          className="mt-5 text-5xl leading-[0.9] text-[#e6392e] sm:text-7xl"
+        >
+          YOU ARE ON THE LIST.
+        </h1>
+        <p className="mt-5 max-w-2xl text-lg font-bold leading-8 text-[#344760]">
+          Thanks for grabbing Bubelpalooza passes. Keep an eye on your inbox for
+          payment confirmation from Stripe, and plan to pick up merch at
+          check-in on Sunday, May 24.
+        </p>
+        <div className="mt-7 grid gap-3 border-y-4 border-[#102344] py-5 sm:grid-cols-3">
+          {[
+            ["12 PM", "Pool opens"],
+            ["1 PM", "Boil hits the table"],
+            ["2:30 PM", "Live music kicks off"],
+          ].map(([time, label]) => (
+            <div key={label} className="bg-[#ffd447] p-4 text-center">
+              <p data-poster="true" className="text-4xl leading-none text-[#e6392e]">
+                {time}
+              </p>
+              <p className="mt-1 text-sm font-black uppercase text-[#102344]">
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+          <Button
+            asChild
+            className="h-auto rounded-none border-4 border-[#102344] bg-[#e6392e] px-6 py-3 text-sm font-black uppercase text-white shadow-[5px_5px_0_#102344] hover:bg-[#cf2f24]"
+          >
+            <Link href="/">Back to event info</Link>
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            className="h-auto rounded-none border-4 border-[#102344] bg-[#fff1c7] px-6 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-white"
+          >
+            <Link href="/merch">Review merch</Link>
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/tickets/ticket-wizard-loader.tsx
+++ b/app/tickets/ticket-wizard-loader.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const TicketWizardLoader = dynamic(
+  () => import("@/app/tickets/ticket-wizard").then((mod) => mod.TicketWizard),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="border-4 border-[#102344] bg-[#fff1c7] p-5 text-sm font-black uppercase text-[#102344] shadow-[8px_8px_0_#102344]">
+        Loading tickets...
+      </div>
+    ),
+  },
+);

--- a/app/tickets/ticket-wizard.tsx
+++ b/app/tickets/ticket-wizard.tsx
@@ -1,0 +1,923 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+import {
+  Check,
+  CreditCard,
+  Plus,
+  Shirt,
+  Ticket,
+  Trash2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  koozieTypeOptions,
+  packageRequiresMerch,
+  shirtColorOptions,
+  shirtSizeOptions,
+  shirtStyleOptions,
+  ticketPackages,
+  type KoozieType,
+  type PackageId,
+  type ShirtColor,
+  type ShirtSize,
+  type ShirtStyle,
+} from "@/lib/merch/catalog";
+import {
+  MAX_PASSES_PER_ORDER,
+  TICKET_CART_STORAGE_KEY,
+  describeKoozieSelection,
+  describeShirtSelection,
+  dollarsToCents,
+  formatCents,
+  getTicketPackage,
+  ticketCartSchema,
+  ticketWizardStorageSchema,
+  type TicketCartInput,
+  type TicketCartPassInput,
+  type TicketWizardPass,
+} from "@/lib/tickets/cart";
+
+type CheckoutResponse = {
+  ok: boolean;
+  url?: string;
+  message?: string;
+};
+
+const inputClassName =
+  "w-full border-4 border-[#102344] bg-[#fff7e6] px-3 py-3 text-base font-black text-[#102344] shadow-[4px_4px_0_#102344] outline-none placeholder:text-[#5f6f86] focus:bg-white";
+const DEFAULT_NAME_YOUR_PRICE_DOLLARS = "7";
+const isCheckoutEnabled =
+  process.env.NEXT_PUBLIC_TICKETS_CHECKOUT_ENABLED === "true";
+const checkoutComingSoonMessage =
+  "Tickets open soon. You can choose your packages now and come back shortly to buy.";
+
+function sanitizeDollarInput(value: string) {
+  const normalized = value.replace(/[^\d.]/g, "");
+  const [dollars = "", ...rest] = normalized.split(".");
+  const cents = rest.join("").slice(0, 2);
+
+  return rest.length > 0 ? `${dollars}.${cents}` : dollars;
+}
+
+function formatDollarInput(value: string) {
+  const cents = dollarsToCents(value);
+
+  if (cents <= 0) {
+    return "0";
+  }
+
+  const dollars = cents / 100;
+
+  return cents % 100 === 0 ? String(dollars) : dollars.toFixed(2);
+}
+
+function createPass(): TicketWizardPass {
+  return {
+    id: typeof crypto !== "undefined" ? crypto.randomUUID() : String(Date.now()),
+    packageId: "complete",
+    nameYourPriceDollars: DEFAULT_NAME_YOUR_PRICE_DOLLARS,
+    shirtStyle: "",
+    shirtColor: "",
+    shirtSize: "",
+    koozieType: "",
+  };
+}
+
+function getInitialWizardState() {
+  const fallback = {
+    passes: [createPass()],
+    donationDollars: "0",
+  };
+
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  const storedCart = window.localStorage.getItem(TICKET_CART_STORAGE_KEY);
+
+  if (!storedCart) {
+    return fallback;
+  }
+
+  try {
+    const parsed = ticketWizardStorageSchema.safeParse(JSON.parse(storedCart));
+
+    return parsed.success ? parsed.data : fallback;
+  } catch {
+    window.localStorage.removeItem(TICKET_CART_STORAGE_KEY);
+    return fallback;
+  }
+}
+
+function normalizePassForPackage(
+  pass: TicketWizardPass,
+  packageId: PackageId,
+): TicketWizardPass {
+  const requirements = packageRequiresMerch(packageId);
+  const nameYourPriceDollars =
+    packageId !== "name-your-price"
+      ? pass.nameYourPriceDollars
+      : pass.packageId === "name-your-price" ||
+          dollarsToCents(pass.nameYourPriceDollars) > 0
+        ? pass.nameYourPriceDollars
+        : DEFAULT_NAME_YOUR_PRICE_DOLLARS;
+
+  return {
+    ...pass,
+    packageId,
+    nameYourPriceDollars,
+    shirtStyle: requirements.shirt ? pass.shirtStyle : "",
+    shirtColor: requirements.shirt ? pass.shirtColor : "",
+    shirtSize: requirements.shirt ? pass.shirtSize : "",
+    koozieType: requirements.koozie ? pass.koozieType : "",
+  };
+}
+
+function getDraftPassPriceCents(pass: TicketWizardPass) {
+  const selectedPackage = getTicketPackage(pass.packageId);
+
+  return selectedPackage.priceCents ?? dollarsToCents(pass.nameYourPriceDollars);
+}
+
+function getDraftPassWarnings(pass: TicketWizardPass) {
+  const requirements = packageRequiresMerch(pass.packageId);
+  const warnings: string[] = [];
+
+  if (requirements.shirt && (!pass.shirtStyle || !pass.shirtColor || !pass.shirtSize)) {
+    warnings.push("Choose shirt style, color, and size.");
+  }
+
+  if (requirements.koozie && !pass.koozieType) {
+    warnings.push("Choose a koozie fit.");
+  }
+
+  return warnings;
+}
+
+function passToCartPass(pass: TicketWizardPass): TicketCartPassInput {
+  const requirements = packageRequiresMerch(pass.packageId);
+  const cartPass: TicketCartPassInput = {
+    packageId: pass.packageId,
+    nameYourPriceCents:
+      pass.packageId === "name-your-price"
+        ? dollarsToCents(pass.nameYourPriceDollars)
+        : 0,
+  };
+
+  if (requirements.shirt && pass.shirtStyle && pass.shirtColor && pass.shirtSize) {
+    cartPass.shirtSelection = {
+      style: pass.shirtStyle,
+      color: pass.shirtColor,
+      size: pass.shirtSize,
+    };
+  }
+
+  if (requirements.koozie && pass.koozieType) {
+    cartPass.koozieSelection = {
+      type: pass.koozieType,
+    };
+  }
+
+  return cartPass;
+}
+
+function buildCart(
+  passes: TicketWizardPass[],
+  donationDollars: string,
+): TicketCartInput {
+  return {
+    passes: passes.map(passToCartPass),
+    donationCents: dollarsToCents(donationDollars),
+  };
+}
+
+function getPassSummary(pass: TicketWizardPass) {
+  const requirements = packageRequiresMerch(pass.packageId);
+  const details: string[] = [];
+
+  if (requirements.shirt) {
+    if (pass.shirtStyle && pass.shirtColor && pass.shirtSize) {
+      details.push(
+        `Shirt: ${describeShirtSelection({
+          style: pass.shirtStyle,
+          color: pass.shirtColor,
+          size: pass.shirtSize,
+        })}`,
+      );
+    } else {
+      details.push("Shirt choice needed.");
+    }
+  }
+
+  if (requirements.koozie) {
+    if (pass.koozieType) {
+      details.push(
+        `Koozie: ${describeKoozieSelection({
+          type: pass.koozieType,
+        })}`,
+      );
+    } else {
+      details.push("Koozie fit needed.");
+    }
+  }
+
+  if (!requirements.shirt && !requirements.koozie) {
+    details.push("No merch choices needed.");
+  }
+
+  return details;
+}
+
+type TicketOption<TValue extends string> = {
+  value: TValue;
+  label: string;
+  description?: string;
+};
+
+function OptionButtonGroup<TValue extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  columns = "grid-cols-2 sm:grid-cols-3",
+}: {
+  label: string;
+  value: TValue | "";
+  options: TicketOption<TValue>[];
+  onChange: (value: TValue) => void;
+  columns?: string;
+}) {
+  return (
+    <div>
+      <p className="mb-2 text-xs font-black uppercase text-[#102344]">{label}</p>
+      <div className={`grid gap-2 ${columns}`}>
+        {options.map((option) => {
+          const isSelected = value === option.value;
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => onChange(option.value)}
+              className={[
+                "min-h-12 border-2 px-3 py-2 text-left text-sm font-black uppercase shadow-[3px_3px_0_#102344] transition hover:-translate-y-0.5",
+                isSelected
+                  ? "border-[#102344] bg-[#183a59] text-[#ffd447]"
+                  : "border-[#102344]/70 bg-[#fff7e6] text-[#102344] hover:bg-white",
+              ].join(" ")}
+            >
+              <span className="flex items-center gap-2">
+                {isSelected ? <Check className="size-4 shrink-0" /> : null}
+                <span>{option.label}</span>
+              </span>
+              {option.description ? (
+                <span className="mt-1 block text-xs font-semibold normal-case leading-4 text-current opacity-80">
+                  {option.description}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function MoneyInput({
+  label,
+  helperText,
+  value,
+  onChange,
+  presets,
+  defaultValue,
+  accent = "blue",
+}: {
+  label: string;
+  helperText?: string;
+  value: string;
+  onChange: (value: string) => void;
+  presets: string[];
+  defaultValue: string;
+  accent?: "blue" | "yellow";
+}) {
+  const inputId = useId();
+  const [isCustomMode, setIsCustomMode] = useState(
+    !presets.includes(formatDollarInput(value)),
+  );
+  const accentClassName =
+    accent === "yellow" ? "bg-[#ffd447]" : "bg-[#2ec4f3]";
+  const formattedValue = formatDollarInput(value);
+  const showCustomInput = isCustomMode;
+
+  return (
+    <div>
+      <p className="mb-2 block text-sm font-black uppercase text-[#102344]">
+        {label}
+      </p>
+      {helperText ? (
+        <p className="mb-2 text-xs font-semibold leading-5 text-[#344760]">
+          {helperText}
+        </p>
+      ) : null}
+
+      <div className="grid grid-cols-4 gap-2">
+        {presets.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => {
+              setIsCustomMode(false);
+              onChange(preset);
+            }}
+            className={[
+              "border-2 border-[#102344] px-2 py-2 text-xs font-black uppercase shadow-[3px_3px_0_#102344] transition hover:-translate-y-0.5",
+              !isCustomMode && formattedValue === preset
+                ? "bg-[#183a59] text-[#ffd447]"
+                : "bg-[#fff7e6] text-[#102344] hover:bg-white",
+            ].join(" ")}
+          >
+            ${preset}
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => {
+          setIsCustomMode(true);
+
+          if (!showCustomInput) {
+            onChange(defaultValue);
+          }
+
+          window.setTimeout(() => document.getElementById(inputId)?.focus(), 0);
+        }}
+        className={[
+          "mt-2 flex min-h-10 w-full items-center justify-center border-2 border-[#102344] px-3 py-2 text-sm font-black uppercase shadow-[3px_3px_0_#102344] transition hover:-translate-y-0.5",
+          showCustomInput
+            ? "bg-[#183a59] text-[#ffd447]"
+            : "bg-[#fff7e6] text-[#102344] hover:bg-white",
+        ].join(" ")}
+      >
+        Custom amount
+      </button>
+
+      {showCustomInput ? (
+        <label htmlFor={inputId} className="mt-3 block">
+          <span className="sr-only">{label}</span>
+          <span className="grid grid-cols-[auto_1fr] items-center">
+            <span
+              className={`border-y-4 border-l-4 border-[#102344] px-4 py-3 text-base font-black text-[#102344] shadow-[4px_4px_0_#102344] ${accentClassName}`}
+            >
+              $
+            </span>
+            <input
+              id={inputId}
+              type="text"
+              inputMode="decimal"
+              value={value}
+              onChange={(event) => onChange(sanitizeDollarInput(event.target.value))}
+              onBlur={() => onChange(formatDollarInput(value))}
+              className={inputClassName}
+            />
+          </span>
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+export function TicketWizard() {
+  const [initialWizardState] = useState(getInitialWizardState);
+  const [passes, setPasses] = useState<TicketWizardPass[]>(
+    initialWizardState.passes,
+  );
+  const [donationDollars, setDonationDollars] = useState(
+    initialWizardState.donationDollars,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  const featuredPackage = ticketPackages.find(
+    (ticketPackage) => ticketPackage.featured,
+  );
+  const additionalPackages = ticketPackages.filter(
+    (ticketPackage) => !ticketPackage.featured,
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      TICKET_CART_STORAGE_KEY,
+      JSON.stringify({
+        passes,
+        donationDollars,
+      }),
+    );
+  }, [donationDollars, passes]);
+
+  const cartInput = useMemo(
+    () => buildCart(passes, donationDollars),
+    [donationDollars, passes],
+  );
+  const cartResult = useMemo(() => ticketCartSchema.safeParse(cartInput), [cartInput]);
+  const passSubtotalCents = passes.reduce(
+    (sum, pass) => sum + getDraftPassPriceCents(pass),
+    0,
+  );
+  const donationCents = dollarsToCents(donationDollars);
+  const totalCents = passSubtotalCents + donationCents;
+  const canAddPass = passes.length < MAX_PASSES_PER_ORDER;
+  const hasMissingSelections = passes.some(
+    (pass) => getDraftPassWarnings(pass).length > 0,
+  );
+
+  function updatePass(
+    passId: string,
+    updater: (pass: TicketWizardPass) => TicketWizardPass,
+  ) {
+    setCheckoutError(null);
+    setPasses((currentPasses) =>
+      currentPasses.map((pass) => (pass.id === passId ? updater(pass) : pass)),
+    );
+  }
+
+  function updatePassPackage(passId: string, packageId: PackageId) {
+    updatePass(passId, (pass) => normalizePassForPackage(pass, packageId));
+  }
+
+  function addPass() {
+    if (!canAddPass) {
+      return;
+    }
+
+    setCheckoutError(null);
+    setPasses((currentPasses) => [...currentPasses, createPass()]);
+  }
+
+  function removePass(passId: string) {
+    setCheckoutError(null);
+    setPasses((currentPasses) =>
+      currentPasses.length === 1
+        ? currentPasses
+        : currentPasses.filter((pass) => pass.id !== passId),
+    );
+  }
+
+  async function handleCheckout() {
+    if (!isCheckoutEnabled) {
+      setCheckoutError(checkoutComingSoonMessage);
+      return;
+    }
+
+    const parsedCart = ticketCartSchema.safeParse(buildCart(passes, donationDollars));
+
+    if (!parsedCart.success) {
+      setCheckoutError("Finish the highlighted choices before checkout.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setCheckoutError(null);
+
+    try {
+      const response = await fetch("/api/tickets/checkout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(parsedCart.data),
+      });
+      const data = (await response.json()) as CheckoutResponse;
+
+      if (!response.ok || !data.ok || !data.url) {
+        setCheckoutError(data.message ?? "Checkout is not available right now.");
+        return;
+      }
+
+      window.location.assign(data.url);
+    } catch {
+      setCheckoutError("Checkout is not available right now. Please try again soon.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const orderSummary = (
+    <>
+      <p className="inline-block bg-[#e6392e] px-3 py-1 text-xs font-black uppercase text-white">
+        Order summary
+      </p>
+      <h2 data-poster="true" className="mt-4 text-4xl leading-none text-[#102344]">
+        {formatCents(totalCents)}
+      </h2>
+
+      <div className="mt-5 space-y-4">
+        {passes.map((pass, passIndex) => (
+          <div
+            key={pass.id}
+            className="border-b-2 border-[#102344]/30 pb-4 last:border-b-0 last:pb-0"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-black uppercase text-[#102344]">
+                  Pass {passIndex + 1}: {getTicketPackage(pass.packageId).shortName}
+                </p>
+                {getPassSummary(pass).map((summary) => (
+                  <p
+                    key={summary}
+                    className="mt-1 text-xs font-semibold leading-5 text-[#344760]"
+                  >
+                    {summary}
+                  </p>
+                ))}
+              </div>
+              <p className="shrink-0 text-sm font-black">
+                {formatCents(getDraftPassPriceCents(pass))}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-5">
+        <MoneyInput
+          label="Extra donation"
+          helperText="Choose an amount or enter your own."
+          value={donationDollars}
+          onChange={(value) => {
+            setCheckoutError(null);
+            setDonationDollars(value);
+          }}
+          presets={["0", "10", "25", "50"]}
+          defaultValue="0"
+          accent="blue"
+        />
+      </div>
+
+      <div className="mt-5 space-y-2 border-y-4 border-[#102344] py-4 text-sm font-black">
+        <div className="flex justify-between gap-3">
+          <span>Passes</span>
+          <span>{formatCents(passSubtotalCents)}</span>
+        </div>
+        <div className="flex justify-between gap-3">
+          <span>Donation</span>
+          <span>{formatCents(donationCents)}</span>
+        </div>
+      </div>
+
+      {checkoutError ? (
+        <p className="mt-4 border-4 border-[#102344] bg-white px-3 py-2 text-sm font-black text-[#e6392e] shadow-[4px_4px_0_#102344]">
+          {checkoutError}
+        </p>
+      ) : !isCheckoutEnabled ? (
+        <p className="mt-4 border-4 border-[#102344] bg-white px-3 py-2 text-sm font-black text-[#344760] shadow-[4px_4px_0_#102344]">
+          {checkoutComingSoonMessage}
+        </p>
+      ) : null}
+
+      <Button
+        type="button"
+        onClick={handleCheckout}
+        disabled={
+          !isCheckoutEnabled ||
+          isSubmitting ||
+          !cartResult.success ||
+          hasMissingSelections
+        }
+        className="mt-5 h-auto w-full rounded-none border-4 border-[#102344] bg-[#e6392e] px-6 py-4 text-sm font-black uppercase text-white shadow-[5px_5px_0_#102344] hover:bg-[#cf2f24] disabled:translate-y-0 disabled:opacity-60"
+      >
+        <CreditCard className="size-4" />
+        {isCheckoutEnabled
+          ? isSubmitting
+            ? "Opening checkout..."
+            : "Secure checkout"
+          : "Checkout coming soon"}
+      </Button>
+
+      <p className="mt-4 text-xs font-semibold leading-5 text-[#344760]">
+        {isCheckoutEnabled
+          ? "Stripe checkout opens in a secure window, and your merch picks stay with your passes for event-day pickup."
+          : "Package picks are open for browsing now. Ticket sales will open soon."}
+      </p>
+    </>
+  );
+
+  return (
+    <div className="grid gap-6 pb-24 lg:grid-cols-[minmax(0,1fr)_24rem] lg:items-start lg:pb-0">
+      <div className="space-y-5">
+        <div className="flex flex-col gap-3 border-4 border-[#102344] bg-[#fff1c7] p-4 shadow-[8px_8px_0_#102344] sm:flex-row sm:items-center sm:justify-between sm:p-5">
+          <div>
+            <p className="inline-flex items-center gap-2 bg-[#102344] px-3 py-1 text-xs font-black uppercase text-[#ffd447]">
+              <Ticket className="size-4" />
+              Build your passes
+            </p>
+            <p className="mt-3 max-w-2xl text-sm font-bold leading-6 text-[#344760] sm:text-base sm:leading-7">
+              Add up to six guests, then choose the package and merch for each
+              pass.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={addPass}
+            disabled={!canAddPass}
+            className="h-auto rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-5 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-[#6fd8f7] disabled:translate-y-0 disabled:opacity-60"
+          >
+            <Plus className="size-4" />
+            Add pass
+          </Button>
+        </div>
+
+        {passes.map((pass, passIndex) => {
+          const warnings = getDraftPassWarnings(pass);
+          const requirements = packageRequiresMerch(pass.packageId);
+
+          return (
+            <article
+              key={pass.id}
+              className="border-4 border-[#102344] bg-[#fff7e6] p-4 text-[#102344] shadow-[8px_8px_0_#102344] sm:p-5"
+            >
+              <div className="flex flex-col gap-3 border-b-4 border-[#102344] pb-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-black uppercase text-[#e6392e]">
+                    Pass {passIndex + 1}
+                  </p>
+                  <h2
+                    data-poster="true"
+                    className="mt-1 text-4xl leading-none text-[#102344]"
+                  >
+                    {getTicketPackage(pass.packageId).shortName} /{" "}
+                    {formatCents(getDraftPassPriceCents(pass))}
+                  </h2>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => removePass(pass.id)}
+                  disabled={passes.length === 1}
+                  className="h-auto rounded-none border-4 border-[#102344] bg-[#fff1c7] px-4 py-2 text-xs font-black uppercase text-[#102344] shadow-[4px_4px_0_#102344] hover:bg-white disabled:translate-y-0 disabled:opacity-50"
+                >
+                  <Trash2 className="size-4" />
+                  Remove
+                </Button>
+              </div>
+
+              <fieldset className="mt-5">
+                <legend className="mb-3 text-sm font-black uppercase text-[#102344]">
+                  Package
+                </legend>
+                <div className="grid gap-4">
+                  {featuredPackage ? (
+                    <button
+                      type="button"
+                      aria-pressed={pass.packageId === featuredPackage.id}
+                      onClick={() => updatePassPackage(pass.id, featuredPackage.id)}
+                      className={[
+                        "grid min-h-40 border-4 p-4 text-left shadow-[5px_5px_0_#102344] transition hover:-translate-y-0.5 sm:grid-cols-[1fr_auto] sm:items-end sm:p-5",
+                        pass.packageId === featuredPackage.id
+                          ? "border-[#102344] bg-[#e6392e] text-white"
+                          : "border-[#102344]/75 bg-[#fff7e6] text-[#102344] hover:bg-white",
+                      ].join(" ")}
+                    >
+                      <span>
+                        <span
+                          className={[
+                            "inline-flex items-center gap-1 px-2 py-1 text-[0.68rem] font-black uppercase",
+                            pass.packageId === featuredPackage.id
+                              ? "bg-[#ffd447] text-[#102344]"
+                              : "bg-[#102344] text-[#ffd447]",
+                          ].join(" ")}
+                        >
+                          {pass.packageId === featuredPackage.id ? (
+                            <Check className="size-3" />
+                          ) : null}
+                          Best deal
+                        </span>
+                        <span
+                          data-poster="true"
+                          className="mt-4 block text-5xl leading-[0.9]"
+                        >
+                          {featuredPackage.shortName}
+                        </span>
+                        <span className="mt-3 block max-w-2xl text-sm font-semibold leading-6">
+                          {featuredPackage.description}
+                        </span>
+                      </span>
+                      <span
+                        data-poster="true"
+                        className="mt-4 block text-5xl leading-none sm:mt-0"
+                      >
+                        {featuredPackage.priceLabel}
+                      </span>
+                    </button>
+                  ) : null}
+
+                  <p className="mx-auto inline-block w-fit bg-[#102344] px-3 py-1 text-center text-xs font-black uppercase text-[#ffd447] shadow-[4px_4px_0_#e6392e]">
+                    Additional ticket options
+                  </p>
+
+                  <div className="grid gap-3 md:grid-cols-3">
+                    {additionalPackages.map((ticketPackage) => {
+                      const isSelected = pass.packageId === ticketPackage.id;
+
+                      return (
+                        <button
+                          key={ticketPackage.id}
+                          type="button"
+                          aria-pressed={isSelected}
+                          onClick={() => updatePassPackage(pass.id, ticketPackage.id)}
+                          className={[
+                            "min-h-36 border-2 p-4 text-left shadow-[3px_3px_0_#102344] transition",
+                            isSelected
+                              ? "border-[#102344] bg-[#183a59] text-white"
+                              : "border-[#102344]/70 bg-[#fff7e6]/80 text-[#102344] hover:bg-white",
+                          ].join(" ")}
+                        >
+                          <span
+                            className={[
+                              "inline-flex items-center gap-1 px-3 py-1 text-base font-black uppercase leading-none",
+                              isSelected
+                                ? "bg-[#ffd447] text-[#102344]"
+                                : "bg-[#102344] text-[#ffd447]",
+                            ].join(" ")}
+                          >
+                            {isSelected ? <Check className="size-3" /> : null}
+                            {ticketPackage.priceLabel}
+                          </span>
+                          <span
+                            data-poster="true"
+                            className="mt-4 block text-3xl leading-[0.92] text-current"
+                          >
+                            {ticketPackage.shortName}
+                          </span>
+                          <span className="mt-3 block text-sm font-semibold leading-6">
+                            {ticketPackage.description}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </fieldset>
+
+              {pass.packageId === "name-your-price" ? (
+                <div className="mt-5 max-w-sm">
+                  <MoneyInput
+                    label="Pass contribution"
+                    helperText="Choose an amount or enter your own."
+                    value={pass.nameYourPriceDollars}
+                    onChange={(value) =>
+                      updatePass(pass.id, (currentPass) => ({
+                        ...currentPass,
+                        nameYourPriceDollars: value,
+                      }))
+                    }
+                    presets={["3", "5", "7", "9"]}
+                    defaultValue={DEFAULT_NAME_YOUR_PRICE_DOLLARS}
+                    accent="yellow"
+                  />
+                </div>
+              ) : null}
+
+              {requirements.shirt || requirements.koozie ? (
+                <div className="mt-5 border-4 border-[#102344] bg-[#ffd447] p-4 shadow-[5px_5px_0_#102344]">
+                  <p className="inline-flex items-center gap-2 bg-[#102344] px-3 py-1 text-xs font-black uppercase text-[#ffd447]">
+                    <Shirt className="size-4" />
+                    Merch choices
+                  </p>
+
+                  {requirements.shirt ? (
+                    <div className="mt-4 grid gap-5">
+                      <OptionButtonGroup
+                        label="Shirt style"
+                        value={pass.shirtStyle}
+                        options={shirtStyleOptions}
+                        columns="grid-cols-2"
+                        onChange={(value: ShirtStyle) =>
+                          updatePass(pass.id, (currentPass) => ({
+                            ...currentPass,
+                            shirtStyle: value,
+                          }))
+                        }
+                      />
+
+                      <OptionButtonGroup
+                        label="Shirt color"
+                        value={pass.shirtColor}
+                        options={shirtColorOptions}
+                        columns="grid-cols-2"
+                        onChange={(value: ShirtColor) =>
+                          updatePass(pass.id, (currentPass) => ({
+                            ...currentPass,
+                            shirtColor: value,
+                          }))
+                        }
+                      />
+
+                      <OptionButtonGroup
+                        label="Shirt size"
+                        value={pass.shirtSize}
+                        options={shirtSizeOptions}
+                        columns="grid-cols-3 sm:grid-cols-6"
+                        onChange={(value: ShirtSize) =>
+                          updatePass(pass.id, (currentPass) => ({
+                            ...currentPass,
+                            shirtSize: value,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+
+                  {requirements.koozie ? (
+                    <div className="mt-5 max-w-2xl">
+                      <OptionButtonGroup
+                        label="Koozie fit"
+                        value={pass.koozieType}
+                        options={koozieTypeOptions}
+                        columns="grid-cols-1 sm:grid-cols-2"
+                        onChange={(value: KoozieType) =>
+                          updatePass(pass.id, (currentPass) => ({
+                            ...currentPass,
+                            koozieType: value,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {warnings.length ? (
+                <div className="mt-5 border-4 border-[#102344] bg-white px-4 py-3 text-sm font-black text-[#e6392e] shadow-[4px_4px_0_#102344]">
+                  {warnings.map((warning) => (
+                    <p key={warning}>{warning}</p>
+                  ))}
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+
+        <div className="flex flex-col gap-3 border-4 border-[#102344] bg-[#fff1c7] p-4 shadow-[8px_8px_0_#102344] sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-black uppercase text-[#102344]">
+              Adding another guest?
+            </p>
+            <p className="mt-1 text-sm font-semibold leading-6 text-[#344760]">
+              Add another pass and choose that guest&apos;s package and merch.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={addPass}
+            disabled={!canAddPass}
+            className="h-auto rounded-none border-4 border-[#102344] bg-[#2ec4f3] px-5 py-3 text-sm font-black uppercase text-[#102344] shadow-[5px_5px_0_#102344] hover:bg-[#6fd8f7] disabled:translate-y-0 disabled:opacity-60"
+          >
+            <Plus className="size-4" />
+            Add pass
+          </Button>
+        </div>
+
+        <section className="border-4 border-[#102344] bg-[#fff1c7] p-4 text-[#102344] shadow-[8px_8px_0_#102344] lg:hidden">
+          {orderSummary}
+        </section>
+      </div>
+
+      <aside className="sticky top-36 hidden border-4 border-[#102344] bg-[#fff1c7] p-4 text-[#102344] shadow-[8px_8px_0_#102344] lg:block lg:p-5">
+        {orderSummary}
+      </aside>
+
+      <div className="fixed inset-x-0 bottom-0 z-50 border-t-4 border-[#102344] bg-[#fff1c7] px-4 py-3 text-[#102344] shadow-[0_-6px_0_rgba(16,35,68,0.16)] lg:hidden">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase text-[#344760]">
+              {passes.length} {passes.length === 1 ? "pass" : "passes"}
+            </p>
+            <p data-poster="true" className="text-3xl leading-none text-[#102344]">
+              {formatCents(totalCents)}
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={handleCheckout}
+            disabled={
+              !isCheckoutEnabled ||
+              isSubmitting ||
+              !cartResult.success ||
+              hasMissingSelections
+            }
+            className="h-auto shrink-0 rounded-none border-4 border-[#102344] bg-[#e6392e] px-4 py-3 text-xs font-black uppercase text-white shadow-[4px_4px_0_#102344] hover:bg-[#cf2f24] disabled:translate-y-0 disabled:opacity-60"
+          >
+            <CreditCard className="size-4" />
+            {isCheckoutEnabled
+              ? isSubmitting
+                ? "Opening..."
+                : "Checkout"
+              : "Soon"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -25,7 +25,7 @@ export function SiteHeader() {
           {[
             ["Experience", "/#experience"],
             ["Schedule", "/#day-schedule"],
-            ["Tickets", "/#complete-package"],
+            ["Tickets", "/tickets"],
             ["Merch", "/merch"],
             ["Lineup", "/#lineup"],
             ["Beach Club", "/#beach-club"],

--- a/docs/merch-assets.md
+++ b/docs/merch-assets.md
@@ -15,4 +15,4 @@ These files are the current event-owner supplied renderings for Bubelpalooza mer
 | Standard/short koozie rendering | `/merch/bubelpalooza-standard-short-koozie.jpg` | `1000014761.jpg` |
 | Sticker rendering | `/merch/bubelpalooza-sticker.jpg` | `1000014765.jpg` |
 
-The ticket package flow can use these paths for package summaries and merch selectors. Shirt sizes are S, M, L, XL, 2XL, 3XL, and 4XL; sizes are represented in product data rather than image filenames.
+The ticket package flow can use these paths for package summaries and merch selectors. Shirt sizes are S, M, L, XL, 2XL, and 3XL; sizes are represented in product data rather than image filenames.

--- a/lib/merch/catalog.ts
+++ b/lib/merch/catalog.ts
@@ -13,7 +13,7 @@ export const MERCH_ASSETS = {
 
 export const SHIRT_STYLE_VALUES = ["tee", "tank"] as const;
 export const SHIRT_COLOR_VALUES = ["black", "white"] as const;
-export const SHIRT_SIZE_VALUES = ["S", "M", "L", "XL", "2XL", "3XL", "4XL"] as const;
+export const SHIRT_SIZE_VALUES = ["S", "M", "L", "XL", "2XL", "3XL"] as const;
 export const KOOZIE_TYPE_VALUES = ["slim-tall", "standard-short"] as const;
 export const PACKAGE_VALUES = [
   "complete",
@@ -109,8 +109,8 @@ export const koozieTypeOptions = [
 export const ticketPackages = [
   {
     id: "complete",
-    name: "Complete package",
-    shortName: "Complete",
+    name: "Ultimate package",
+    shortName: "Ultimate",
     priceCents: 2500,
     priceLabel: "$25",
     description: "Entry, food, sticker, koozie, and shirt.",
@@ -121,8 +121,8 @@ export const ticketPackages = [
   },
   {
     id: "koozie",
-    name: "Koozie package",
-    shortName: "Koozie",
+    name: "Koozie+ package",
+    shortName: "Koozie+",
     priceCents: 1500,
     priceLabel: "$15",
     description: "Entry, food, sticker, and koozie.",
@@ -132,8 +132,8 @@ export const ticketPackages = [
   },
   {
     id: "sticker",
-    name: "Sticker package",
-    shortName: "Sticker",
+    name: "Sticker+ package",
+    shortName: "Sticker+",
     priceCents: 1000,
     priceLabel: "$10",
     description: "Entry, food, and sticker.",
@@ -161,12 +161,12 @@ export const merchProducts = [
     name: "Event shirt",
     eyebrow: "Tee or tank",
     description:
-      "Choose tee or tank, black or white, with sizes from S through 4XL.",
+      "Choose tee or tank, black or white, with sizes from S through 3XL.",
     image: {
       src: MERCH_ASSETS.blackTee,
       alt: "Black Bubelpalooza event tee rendering with crawfish and beach club artwork.",
     },
-    options: ["Tee or tank", "Black or white", "S to 4XL"],
+    options: ["Tee or tank", "Black or white", "S to 3XL"],
   },
   {
     id: "koozie",

--- a/lib/tickets/cart.ts
+++ b/lib/tickets/cart.ts
@@ -1,0 +1,203 @@
+import { z } from "zod";
+import {
+  KOOZIE_TYPE_VALUES,
+  PACKAGE_VALUES,
+  SHIRT_COLOR_VALUES,
+  SHIRT_SIZE_VALUES,
+  SHIRT_STYLE_VALUES,
+  koozieSelectionSchema,
+  packageRequiresMerch,
+  packageSchema,
+  shirtSelectionSchema,
+  ticketPackages,
+  type KoozieSelection,
+  type KoozieType,
+  type PackageId,
+  type ShirtColor,
+  type ShirtSelection,
+  type ShirtSize,
+  type ShirtStyle,
+  type TicketPackage,
+} from "@/lib/merch/catalog";
+
+export const MAX_PASSES_PER_ORDER = 6;
+export const TICKET_CART_STORAGE_KEY = "bubelpalooza-ticket-cart";
+
+export const centsSchema = z
+  .number()
+  .int("must be a whole number of cents")
+  .min(0, "must be zero or more")
+  .max(100_000, "must be $1,000 or less");
+
+export const ticketCartPassSchema = z
+  .object({
+    packageId: packageSchema,
+    nameYourPriceCents: centsSchema.optional().default(0),
+    shirtSelection: shirtSelectionSchema.optional(),
+    koozieSelection: koozieSelectionSchema.optional(),
+  })
+  .superRefine((pass, context) => {
+    const requirements = packageRequiresMerch(pass.packageId);
+
+    if (pass.packageId !== "name-your-price" && pass.nameYourPriceCents > 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["nameYourPriceCents"],
+        message: "is only available for name-your-price passes",
+      });
+    }
+
+    if (requirements.shirt && !pass.shirtSelection) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["shirtSelection"],
+        message: "is required for this package",
+      });
+    }
+
+    if (!requirements.shirt && pass.shirtSelection) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["shirtSelection"],
+        message: "is not available for this package",
+      });
+    }
+
+    if (requirements.koozie && !pass.koozieSelection) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["koozieSelection"],
+        message: "is required for this package",
+      });
+    }
+
+    if (!requirements.koozie && pass.koozieSelection) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["koozieSelection"],
+        message: "is not available for this package",
+      });
+    }
+  });
+
+export const ticketCartSchema = z.object({
+  passes: z
+    .array(ticketCartPassSchema)
+    .min(1, "Add at least one pass")
+    .max(MAX_PASSES_PER_ORDER, `Orders can include up to ${MAX_PASSES_PER_ORDER} passes`),
+  donationCents: centsSchema.optional().default(0),
+});
+
+export const ticketWizardStoredPassSchema = z.object({
+  id: z.string().min(1),
+  packageId: z.enum(PACKAGE_VALUES),
+  nameYourPriceDollars: z.string(),
+  shirtStyle: z.union([z.enum(SHIRT_STYLE_VALUES), z.literal("")]),
+  shirtColor: z.union([z.enum(SHIRT_COLOR_VALUES), z.literal("")]),
+  shirtSize: z.union([z.enum(SHIRT_SIZE_VALUES), z.literal("")]),
+  koozieType: z.union([z.enum(KOOZIE_TYPE_VALUES), z.literal("")]),
+});
+
+export const ticketWizardStorageSchema = z.object({
+  passes: z
+    .array(ticketWizardStoredPassSchema)
+    .min(1)
+    .max(MAX_PASSES_PER_ORDER),
+  donationDollars: z.string(),
+});
+
+export type TicketCartPassInput = z.input<typeof ticketCartPassSchema>;
+export type TicketCartInput = z.input<typeof ticketCartSchema>;
+export type TicketCartPass = z.output<typeof ticketCartPassSchema>;
+export type TicketCart = z.output<typeof ticketCartSchema>;
+export type TicketWizardStoredPass = z.infer<typeof ticketWizardStoredPassSchema>;
+export type TicketWizardStorage = z.infer<typeof ticketWizardStorageSchema>;
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+export function getTicketPackage(packageId: PackageId): TicketPackage {
+  const selectedPackage = ticketPackages.find(
+    (ticketPackage) => ticketPackage.id === packageId,
+  );
+
+  if (!selectedPackage) {
+    throw new Error(`Ticket package ${packageId} is not configured.`);
+  }
+
+  return selectedPackage;
+}
+
+export function formatCents(cents: number) {
+  return currencyFormatter.format(cents / 100);
+}
+
+export function dollarsToCents(value: string) {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+
+  return Math.round(parsed * 100);
+}
+
+export function getPassPriceCents(pass: TicketCartPass) {
+  const selectedPackage = getTicketPackage(pass.packageId);
+
+  return selectedPackage.priceCents ?? pass.nameYourPriceCents;
+}
+
+export function getCartTotals(cart: TicketCart) {
+  const passSubtotalCents = cart.passes.reduce(
+    (sum, pass) => sum + getPassPriceCents(pass),
+    0,
+  );
+  const totalCents = passSubtotalCents + cart.donationCents;
+
+  return {
+    passSubtotalCents,
+    donationCents: cart.donationCents,
+    totalCents,
+  };
+}
+
+export function describeShirtSelection(selection: ShirtSelection) {
+  return `${selection.color} ${selection.style}, size ${selection.size}`;
+}
+
+export function describeKoozieSelection(selection: KoozieSelection) {
+  return selection.type === "slim-tall" ? "slim/tall koozie" : "standard/short koozie";
+}
+
+export function describePassSelection(pass: TicketCartPass) {
+  const selectedPackage = getTicketPackage(pass.packageId);
+  const details = [selectedPackage.description];
+
+  if (pass.shirtSelection) {
+    details.push(`Shirt: ${describeShirtSelection(pass.shirtSelection)}.`);
+  }
+
+  if (pass.koozieSelection) {
+    details.push(`Koozie: ${describeKoozieSelection(pass.koozieSelection)}.`);
+  }
+
+  if (pass.packageId === "name-your-price") {
+    details.push(`Pass contribution: ${formatCents(pass.nameYourPriceCents)}.`);
+  }
+
+  return details.join(" ");
+}
+
+export type TicketWizardPass = {
+  id: string;
+  packageId: PackageId;
+  nameYourPriceDollars: string;
+  shirtStyle: ShirtStyle | "";
+  shirtColor: ShirtColor | "";
+  shirtSize: ShirtSize | "";
+  koozieType: KoozieType | "";
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "19.2.4",
         "resend": "^6.12.3",
         "shadcn": "^4.5.0",
+        "stripe": "^22.1.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.4.3"
@@ -11220,6 +11221,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "copy:check": "node scripts/check-public-copy.mjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
@@ -24,6 +25,7 @@
     "react-dom": "19.2.4",
     "resend": "^6.12.3",
     "shadcn": "^4.5.0",
+    "stripe": "^22.1.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3"

--- a/scripts/check-public-copy.mjs
+++ b/scripts/check-public-copy.mjs
@@ -1,0 +1,61 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const roots = ["app", "components"];
+const extensions = new Set([".tsx", ".ts"]);
+const blockedPhrases = [
+  "acceptance criteria",
+  "current rendering",
+  "fulfillment details",
+  "payment will turn on",
+  "purchase touchpoint",
+  "the layout should",
+  "the site should",
+  "this implementation",
+  "this requirement",
+  "this wizard",
+];
+
+function getFiles(directory) {
+  return readdirSync(directory).flatMap((entry) => {
+    const fullPath = path.join(directory, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      return getFiles(fullPath);
+    }
+
+    return extensions.has(path.extname(fullPath)) ? [fullPath] : [];
+  });
+}
+
+function getQuotedText(content) {
+  const matches = content.matchAll(/(["'`])((?:(?!\1)[^\\]|\\.)*)\1/gms);
+
+  return Array.from(matches, (match) => match[2].replaceAll(/\s+/g, " "));
+}
+
+const findings = roots
+  .flatMap(getFiles)
+  .flatMap((filePath) => {
+    const content = readFileSync(filePath, "utf8");
+    const quotedText = getQuotedText(content);
+
+    return quotedText.flatMap((text) =>
+      blockedPhrases
+        .filter((phrase) => text.toLowerCase().includes(phrase))
+        .map((phrase) => ({ filePath, phrase, text })),
+    );
+  });
+
+if (findings.length > 0) {
+  console.error("Public copy check found implementation-facing language:");
+
+  for (const finding of findings) {
+    console.error(`- ${finding.filePath}: "${finding.phrase}" in "${finding.text}"`);
+  }
+
+  process.exit(1);
+}
+
+console.log("Public copy check passed.");


### PR DESCRIPTION
## Summary
- Add the public ticket package builder with up to six passes, per-pass merch choices, name-your-price contributions, and an order donation prompt
- Add a guarded Stripe Checkout session route with Bubelpalooza branding, success page, and cart clearing after successful return
- Update ticket/merch copy and CTAs, remove 4XL shirt sizing, and add a small public-copy check for implementation-facing phrases

## Validation
- npm run copy:check
- npm run lint
- npx tsc --noEmit
- npm run build

## Follow-up Work
- Order schema and persistence remain in #8 and #13
- Stripe webhook completion handling remains in #10
- Confirmation email work remains in #14
- Fulfillment/counts work remains in #50

Closes #11