### PR TITLE
Create ticket order schema

### DIFF
--- a/app/api/tickets/checkout/route.ts
+++ b/app/api/tickets/checkout/route.ts
@@ -53,7 +53,7 @@ function getCheckoutBrandingSettings(): CheckoutBrandingSettings {
 }
 
 function getPackageImagePath(packageId: TicketCartPass["packageId"]) {
-  if (packageId === "complete") {
+  if (packageId === "ultimate") {
     return MERCH_ASSETS.lineupCutout;
   }
 

--- a/app/merch/page.tsx
+++ b/app/merch/page.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
     "Preview the $25 Bubelpalooza ultimate package with entry, boil, shirt, koozie, and sticker.",
 };
 
-function getCompletePackage() {
+function getUltimatePackage() {
   const packageDetails = ticketPackages.find(
-    (ticketPackage) => ticketPackage.id === "complete",
+    (ticketPackage) => ticketPackage.id === "ultimate",
   );
 
   if (!packageDetails) {
@@ -22,13 +22,13 @@ function getCompletePackage() {
   return packageDetails;
 }
 
-const completeIncludes = ["Entry", "Boil", "Shirt", "Koozie", "Sticker"];
+const ultimateIncludes = ["Entry", "Boil", "Shirt", "Koozie", "Sticker"];
 const viewportSafeWidth = {
   width: "min(100%, calc(100vw - 2.5rem))",
 };
 
 export default function MerchPage() {
-  const completePackage = getCompletePackage();
+  const ultimatePackage = getUltimatePackage();
 
   return (
     <div className="bg-[#ffd447] text-[#102344]">
@@ -59,7 +59,7 @@ export default function MerchPage() {
                 size="lg"
                 className="h-auto w-full rounded-none border-4 border-[#102344] bg-[#e6392e] px-7 py-4 text-base font-black uppercase text-white shadow-[6px_6px_0_#102344] hover:bg-[#cf2f24] sm:w-auto"
               >
-                <Link href="#complete-package">Included</Link>
+                <Link href="#ultimate-package">Included</Link>
               </Button>
               <Button
                 asChild
@@ -89,7 +89,7 @@ export default function MerchPage() {
       </section>
 
       <section
-        id="complete-package"
+        id="ultimate-package"
         className="scroll-mt-36 bg-[#fff1c7] px-5 py-12 text-[#102344] sm:px-8 lg:scroll-mt-28 lg:px-10"
       >
         <div className="mx-auto grid max-w-7xl grid-cols-1 gap-8 lg:grid-cols-[0.76fr_1.24fr] lg:items-start">
@@ -101,7 +101,7 @@ export default function MerchPage() {
               data-poster="true"
               className="mt-5 text-5xl leading-[0.9] text-[#102344] sm:text-7xl"
             >
-              {completePackage.priceLabel} FOR THE WHOLE DAY.
+              {ultimatePackage.priceLabel} FOR THE WHOLE DAY.
             </h2>
             <p className="mt-5 max-w-xl border-l-8 border-[#2ec4f3] bg-[#102344] px-5 py-4 text-lg font-semibold leading-8 text-[#fff7e6] shadow-[8px_8px_0_#e6392e]">
               Pick it up at check-in, then settle in for crawfish, pool time,
@@ -122,19 +122,19 @@ export default function MerchPage() {
                   data-poster="true"
                   className="mt-4 text-5xl leading-[0.88] sm:text-6xl"
                 >
-                  {completePackage.name}
+                  {ultimatePackage.name}
                 </h3>
               </div>
               <p
                 data-poster="true"
                 className="bg-[#102344] px-4 py-3 text-6xl leading-none text-[#ffd447]"
               >
-                {completePackage.priceLabel}
+                {ultimatePackage.priceLabel}
               </p>
             </div>
 
             <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-5">
-              {completeIncludes.map((item) => (
+              {ultimateIncludes.map((item) => (
                 <p
                   key={item}
                   className="border-2 border-white bg-[#102344] px-3 py-3 text-center text-sm font-black uppercase text-[#ffd447]"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,11 +45,11 @@ const ticketNotes = [
   },
 ];
 
-const completeIncludes = ["Entry", "Boil", "Shirt", "Koozie", "Sticker"];
+const ultimateIncludes = ["Entry", "Boil", "Shirt", "Koozie", "Sticker"];
 
-function getCompletePackage() {
+function getUltimatePackage() {
   const packageDetails = ticketPackages.find(
-    (ticketPackage) => ticketPackage.id === "complete",
+    (ticketPackage) => ticketPackage.id === "ultimate",
   );
 
   if (!packageDetails) {
@@ -60,7 +60,7 @@ function getCompletePackage() {
 }
 
 export default function Home() {
-  const completePackage = getCompletePackage();
+  const ultimatePackage = getUltimatePackage();
 
   return (
     <div className="overflow-hidden bg-[#ffd447] text-[#102344]">
@@ -175,7 +175,7 @@ export default function Home() {
       </section>
 
       <section
-        id="complete-package"
+        id="ultimate-package"
         className="relative isolate overflow-hidden border-b-[10px] border-[#102344] bg-[#fff1c7] px-5 py-12 text-[#102344] sm:px-8 lg:px-10"
       >
         <div className="absolute inset-y-0 left-0 -z-10 hidden w-[46%] bg-[#ffd447] lg:block" />
@@ -193,7 +193,7 @@ export default function Home() {
             >
               <span className="block">THE</span>
               <span className="block text-[#e6392e]">
-                {completePackage.priceLabel}
+                {ultimatePackage.priceLabel}
               </span>
               <span className="block">PACKAGE.</span>
             </h2>
@@ -202,7 +202,7 @@ export default function Home() {
             </p>
 
             <div className="mt-6 grid max-w-xl grid-cols-2 gap-3 sm:grid-cols-5">
-              {completeIncludes.map((item) => (
+              {ultimateIncludes.map((item) => (
                 <span
                   key={item}
                   className="border-2 border-[#102344] bg-[#ffd447] px-3 py-3 text-center text-sm font-black uppercase text-[#102344] shadow-[4px_4px_0_#102344]"

--- a/app/tickets/ticket-wizard.tsx
+++ b/app/tickets/ticket-wizard.tsx
@@ -75,7 +75,7 @@ function formatDollarInput(value: string) {
 function createPass(): TicketWizardPass {
   return {
     id: typeof crypto !== "undefined" ? crypto.randomUUID() : String(Date.now()),
-    packageId: "complete",
+    packageId: "ultimate",
     nameYourPriceDollars: DEFAULT_NAME_YOUR_PRICE_DOLLARS,
     shirtStyle: "",
     shirtColor: "",

--- a/drizzle/0002_empty_the_professor.sql
+++ b/drizzle/0002_empty_the_professor.sql
@@ -1,0 +1,85 @@
+CREATE TYPE "public"."ticket_koozie_type" AS ENUM('slim-tall', 'standard-short');--> statement-breakpoint
+CREATE TYPE "public"."ticket_order_status" AS ENUM('pending', 'completed', 'failed', 'canceled');--> statement-breakpoint
+CREATE TYPE "public"."ticket_package_id" AS ENUM('ultimate', 'koozie', 'sticker', 'name-your-price');--> statement-breakpoint
+CREATE TYPE "public"."ticket_payment_provider" AS ENUM('stripe', 'none');--> statement-breakpoint
+CREATE TYPE "public"."ticket_payment_status" AS ENUM('unpaid', 'paid', 'no_payment_required', 'failed', 'refunded');--> statement-breakpoint
+CREATE TYPE "public"."ticket_shirt_color" AS ENUM('black', 'white');--> statement-breakpoint
+CREATE TYPE "public"."ticket_shirt_size" AS ENUM('S', 'M', 'L', 'XL', '2XL', '3XL');--> statement-breakpoint
+CREATE TYPE "public"."ticket_shirt_style" AS ENUM('tee', 'tank');--> statement-breakpoint
+CREATE TABLE "ticket_order_passes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"order_id" uuid NOT NULL,
+	"pass_number" integer NOT NULL,
+	"package_id" "ticket_package_id" NOT NULL,
+	"price_cents" integer NOT NULL,
+	"name_your_price_cents" integer DEFAULT 0 NOT NULL,
+	"shirt_style" "ticket_shirt_style",
+	"shirt_color" "ticket_shirt_color",
+	"shirt_size" "ticket_shirt_size",
+	"koozie_type" "ticket_koozie_type",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ticket_order_passes_pass_number_range" CHECK ("ticket_order_passes"."pass_number" >= 1 and "ticket_order_passes"."pass_number" <= 6),
+	CONSTRAINT "ticket_order_passes_amounts_nonnegative" CHECK ("ticket_order_passes"."price_cents" >= 0 and "ticket_order_passes"."name_your_price_cents" >= 0),
+	CONSTRAINT "ticket_order_passes_name_your_price_matches_package" CHECK ((
+        "ticket_order_passes"."package_id" = 'name-your-price' and
+        "ticket_order_passes"."name_your_price_cents" = "ticket_order_passes"."price_cents"
+      ) or (
+        "ticket_order_passes"."package_id" <> 'name-your-price' and
+        "ticket_order_passes"."name_your_price_cents" = 0
+      )),
+	CONSTRAINT "ticket_order_passes_merch_matches_package" CHECK ((
+        "ticket_order_passes"."package_id" = 'ultimate' and
+        "ticket_order_passes"."shirt_style" is not null and
+        "ticket_order_passes"."shirt_color" is not null and
+        "ticket_order_passes"."shirt_size" is not null and
+        "ticket_order_passes"."koozie_type" is not null
+      ) or (
+        "ticket_order_passes"."package_id" = 'koozie' and
+        "ticket_order_passes"."shirt_style" is null and
+        "ticket_order_passes"."shirt_color" is null and
+        "ticket_order_passes"."shirt_size" is null and
+        "ticket_order_passes"."koozie_type" is not null
+      ) or (
+        "ticket_order_passes"."package_id" in ('sticker', 'name-your-price') and
+        "ticket_order_passes"."shirt_style" is null and
+        "ticket_order_passes"."shirt_color" is null and
+        "ticket_order_passes"."shirt_size" is null and
+        "ticket_order_passes"."koozie_type" is null
+      ))
+);
+--> statement-breakpoint
+CREATE TABLE "ticket_orders" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"status" "ticket_order_status" DEFAULT 'pending' NOT NULL,
+	"payment_status" "ticket_payment_status" DEFAULT 'unpaid' NOT NULL,
+	"payment_provider" "ticket_payment_provider" NOT NULL,
+	"currency" text DEFAULT 'usd' NOT NULL,
+	"pass_count" integer NOT NULL,
+	"pass_subtotal_cents" integer NOT NULL,
+	"donation_cents" integer DEFAULT 0 NOT NULL,
+	"total_cents" integer NOT NULL,
+	"customer_name" text,
+	"customer_email" text,
+	"stripe_checkout_session_id" text,
+	"stripe_checkout_status" text,
+	"stripe_payment_intent_id" text,
+	"stripe_payment_status" text,
+	"stripe_customer_id" text,
+	"stripe_client_reference_id" text,
+	"completed_at" timestamp with time zone,
+	"canceled_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ticket_orders_pass_count_range" CHECK ("ticket_orders"."pass_count" >= 1 and "ticket_orders"."pass_count" <= 6),
+	CONSTRAINT "ticket_orders_amounts_nonnegative" CHECK ("ticket_orders"."pass_subtotal_cents" >= 0 and "ticket_orders"."donation_cents" >= 0 and "ticket_orders"."total_cents" >= 0),
+	CONSTRAINT "ticket_orders_total_matches_parts" CHECK ("ticket_orders"."total_cents" = "ticket_orders"."pass_subtotal_cents" + "ticket_orders"."donation_cents")
+);
+--> statement-breakpoint
+ALTER TABLE "ticket_order_passes" ADD CONSTRAINT "ticket_order_passes_order_id_ticket_orders_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."ticket_orders"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "ticket_order_passes_order_id_pass_number_unique" ON "ticket_order_passes" USING btree ("order_id","pass_number");--> statement-breakpoint
+CREATE INDEX "ticket_order_passes_order_id_idx" ON "ticket_order_passes" USING btree ("order_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "ticket_orders_stripe_checkout_session_id_unique" ON "ticket_orders" USING btree ("stripe_checkout_session_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "ticket_orders_stripe_payment_intent_id_unique" ON "ticket_orders" USING btree ("stripe_payment_intent_id");--> statement-breakpoint
+CREATE INDEX "ticket_orders_status_idx" ON "ticket_orders" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "ticket_orders_customer_email_idx" ON "ticket_orders" USING btree ("customer_email");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,591 @@
+{
+  "id": "775a169e-142b-4c0e-ae50-cdba2625b635",
+  "prevId": "521fab74-bea3-4aac-afde-f366d00409d5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.event_update_signups": {
+      "name": "event_update_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "sms_consent_status": {
+          "name": "sms_consent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_subscribed'"
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_copy_version": {
+          "name": "sms_consent_copy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_update_signups_email_unique": {
+          "name": "event_update_signups_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "event_update_signups_phone_number_unique": {
+          "name": "event_update_signups_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_order_passes": {
+      "name": "ticket_order_passes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_number": {
+          "name": "pass_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "ticket_package_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_your_price_cents": {
+          "name": "name_your_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shirt_style": {
+          "name": "shirt_style",
+          "type": "ticket_shirt_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shirt_color": {
+          "name": "shirt_color",
+          "type": "ticket_shirt_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shirt_size": {
+          "name": "shirt_size",
+          "type": "ticket_shirt_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koozie_type": {
+          "name": "koozie_type",
+          "type": "ticket_koozie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ticket_order_passes_order_id_pass_number_unique": {
+          "name": "ticket_order_passes_order_id_pass_number_unique",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pass_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_order_passes_order_id_idx": {
+          "name": "ticket_order_passes_order_id_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_order_passes_order_id_ticket_orders_id_fk": {
+          "name": "ticket_order_passes_order_id_ticket_orders_id_fk",
+          "tableFrom": "ticket_order_passes",
+          "tableTo": "ticket_orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ticket_order_passes_pass_number_range": {
+          "name": "ticket_order_passes_pass_number_range",
+          "value": "\"ticket_order_passes\".\"pass_number\" >= 1 and \"ticket_order_passes\".\"pass_number\" <= 6"
+        },
+        "ticket_order_passes_amounts_nonnegative": {
+          "name": "ticket_order_passes_amounts_nonnegative",
+          "value": "\"ticket_order_passes\".\"price_cents\" >= 0 and \"ticket_order_passes\".\"name_your_price_cents\" >= 0"
+        },
+        "ticket_order_passes_name_your_price_matches_package": {
+          "name": "ticket_order_passes_name_your_price_matches_package",
+          "value": "(\n        \"ticket_order_passes\".\"package_id\" = 'name-your-price' and\n        \"ticket_order_passes\".\"name_your_price_cents\" = \"ticket_order_passes\".\"price_cents\"\n      ) or (\n        \"ticket_order_passes\".\"package_id\" <> 'name-your-price' and\n        \"ticket_order_passes\".\"name_your_price_cents\" = 0\n      )"
+        },
+        "ticket_order_passes_merch_matches_package": {
+          "name": "ticket_order_passes_merch_matches_package",
+          "value": "(\n        \"ticket_order_passes\".\"package_id\" = 'ultimate' and\n        \"ticket_order_passes\".\"shirt_style\" is not null and\n        \"ticket_order_passes\".\"shirt_color\" is not null and\n        \"ticket_order_passes\".\"shirt_size\" is not null and\n        \"ticket_order_passes\".\"koozie_type\" is not null\n      ) or (\n        \"ticket_order_passes\".\"package_id\" = 'koozie' and\n        \"ticket_order_passes\".\"shirt_style\" is null and\n        \"ticket_order_passes\".\"shirt_color\" is null and\n        \"ticket_order_passes\".\"shirt_size\" is null and\n        \"ticket_order_passes\".\"koozie_type\" is not null\n      ) or (\n        \"ticket_order_passes\".\"package_id\" in ('sticker', 'name-your-price') and\n        \"ticket_order_passes\".\"shirt_style\" is null and\n        \"ticket_order_passes\".\"shirt_color\" is null and\n        \"ticket_order_passes\".\"shirt_size\" is null and\n        \"ticket_order_passes\".\"koozie_type\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ticket_orders": {
+      "name": "ticket_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "ticket_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_provider": {
+          "name": "payment_provider",
+          "type": "ticket_payment_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "pass_count": {
+          "name": "pass_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_subtotal_cents": {
+          "name": "pass_subtotal_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donation_cents": {
+          "name": "donation_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_status": {
+          "name": "stripe_checkout_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_status": {
+          "name": "stripe_payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_client_reference_id": {
+          "name": "stripe_client_reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ticket_orders_stripe_checkout_session_id_unique": {
+          "name": "ticket_orders_stripe_checkout_session_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_orders_stripe_payment_intent_id_unique": {
+          "name": "ticket_orders_stripe_payment_intent_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_orders_status_idx": {
+          "name": "ticket_orders_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_orders_customer_email_idx": {
+          "name": "ticket_orders_customer_email_idx",
+          "columns": [
+            {
+              "expression": "customer_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ticket_orders_pass_count_range": {
+          "name": "ticket_orders_pass_count_range",
+          "value": "\"ticket_orders\".\"pass_count\" >= 1 and \"ticket_orders\".\"pass_count\" <= 6"
+        },
+        "ticket_orders_amounts_nonnegative": {
+          "name": "ticket_orders_amounts_nonnegative",
+          "value": "\"ticket_orders\".\"pass_subtotal_cents\" >= 0 and \"ticket_orders\".\"donation_cents\" >= 0 and \"ticket_orders\".\"total_cents\" >= 0"
+        },
+        "ticket_orders_total_matches_parts": {
+          "name": "ticket_orders_total_matches_parts",
+          "value": "\"ticket_orders\".\"total_cents\" = \"ticket_orders\".\"pass_subtotal_cents\" + \"ticket_orders\".\"donation_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ticket_koozie_type": {
+      "name": "ticket_koozie_type",
+      "schema": "public",
+      "values": [
+        "slim-tall",
+        "standard-short"
+      ]
+    },
+    "public.ticket_order_status": {
+      "name": "ticket_order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.ticket_package_id": {
+      "name": "ticket_package_id",
+      "schema": "public",
+      "values": [
+        "ultimate",
+        "koozie",
+        "sticker",
+        "name-your-price"
+      ]
+    },
+    "public.ticket_payment_provider": {
+      "name": "ticket_payment_provider",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "none"
+      ]
+    },
+    "public.ticket_payment_status": {
+      "name": "ticket_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid",
+        "no_payment_required",
+        "failed",
+        "refunded"
+      ]
+    },
+    "public.ticket_shirt_color": {
+      "name": "ticket_shirt_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.ticket_shirt_size": {
+      "name": "ticket_shirt_size",
+      "schema": "public",
+      "values": [
+        "S",
+        "M",
+        "L",
+        "XL",
+        "2XL",
+        "3XL"
+      ]
+    },
+    "public.ticket_shirt_style": {
+      "name": "ticket_shirt_style",
+      "schema": "public",
+      "values": [
+        "tee",
+        "tank"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778264885171,
       "tag": "0001_elite_ultragirl",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1779306537471,
+      "tag": "0002_empty_the_professor",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -1,4 +1,23 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import {
+  KOOZIE_TYPE_VALUES,
+  MAX_PASSES_PER_ORDER,
+  PACKAGE_VALUES,
+  SHIRT_COLOR_VALUES,
+  SHIRT_SIZE_VALUES,
+  SHIRT_STYLE_VALUES,
+} from "@/lib/tickets/constants";
 
 export const eventUpdateSignups = pgTable("event_update_signups", {
   id: uuid("id").defaultRandom().primaryKey(),
@@ -16,5 +35,157 @@ export const eventUpdateSignups = pgTable("event_update_signups", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
+export const ticketOrderStatusEnum = pgEnum("ticket_order_status", [
+  "pending",
+  "completed",
+  "failed",
+  "canceled",
+]);
+
+export const ticketPaymentStatusEnum = pgEnum("ticket_payment_status", [
+  "unpaid",
+  "paid",
+  "no_payment_required",
+  "failed",
+  "refunded",
+]);
+
+export const ticketPaymentProviderEnum = pgEnum("ticket_payment_provider", [
+  "stripe",
+  "none",
+]);
+
+export const ticketPackageIdEnum = pgEnum("ticket_package_id", PACKAGE_VALUES);
+export const ticketShirtStyleEnum = pgEnum("ticket_shirt_style", SHIRT_STYLE_VALUES);
+export const ticketShirtColorEnum = pgEnum("ticket_shirt_color", SHIRT_COLOR_VALUES);
+export const ticketShirtSizeEnum = pgEnum("ticket_shirt_size", SHIRT_SIZE_VALUES);
+export const ticketKoozieTypeEnum = pgEnum("ticket_koozie_type", KOOZIE_TYPE_VALUES);
+
+export const ticketOrders = pgTable(
+  "ticket_orders",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    status: ticketOrderStatusEnum("status").notNull().default("pending"),
+    paymentStatus: ticketPaymentStatusEnum("payment_status")
+      .notNull()
+      .default("unpaid"),
+    paymentProvider: ticketPaymentProviderEnum("payment_provider").notNull(),
+    currency: text("currency").notNull().default("usd"),
+    passCount: integer("pass_count").notNull(),
+    passSubtotalCents: integer("pass_subtotal_cents").notNull(),
+    donationCents: integer("donation_cents").notNull().default(0),
+    totalCents: integer("total_cents").notNull(),
+    customerName: text("customer_name"),
+    customerEmail: text("customer_email"),
+    stripeCheckoutSessionId: text("stripe_checkout_session_id"),
+    stripeCheckoutStatus: text("stripe_checkout_status"),
+    stripePaymentIntentId: text("stripe_payment_intent_id"),
+    stripePaymentStatus: text("stripe_payment_status"),
+    stripeCustomerId: text("stripe_customer_id"),
+    stripeClientReferenceId: text("stripe_client_reference_id"),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    canceledAt: timestamp("canceled_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("ticket_orders_stripe_checkout_session_id_unique").on(
+      table.stripeCheckoutSessionId,
+    ),
+    uniqueIndex("ticket_orders_stripe_payment_intent_id_unique").on(
+      table.stripePaymentIntentId,
+    ),
+    index("ticket_orders_status_idx").on(table.status),
+    index("ticket_orders_customer_email_idx").on(table.customerEmail),
+    check(
+      "ticket_orders_pass_count_range",
+      sql`${table.passCount} >= 1 and ${table.passCount} <= ${sql.raw(
+        String(MAX_PASSES_PER_ORDER),
+      )}`,
+    ),
+    check(
+      "ticket_orders_amounts_nonnegative",
+      sql`${table.passSubtotalCents} >= 0 and ${table.donationCents} >= 0 and ${table.totalCents} >= 0`,
+    ),
+    check(
+      "ticket_orders_total_matches_parts",
+      sql`${table.totalCents} = ${table.passSubtotalCents} + ${table.donationCents}`,
+    ),
+  ],
+);
+
+export const ticketOrderPasses = pgTable(
+  "ticket_order_passes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    orderId: uuid("order_id")
+      .notNull()
+      .references(() => ticketOrders.id, { onDelete: "cascade" }),
+    passNumber: integer("pass_number").notNull(),
+    packageId: ticketPackageIdEnum("package_id").notNull(),
+    priceCents: integer("price_cents").notNull(),
+    nameYourPriceCents: integer("name_your_price_cents").notNull().default(0),
+    shirtStyle: ticketShirtStyleEnum("shirt_style"),
+    shirtColor: ticketShirtColorEnum("shirt_color"),
+    shirtSize: ticketShirtSizeEnum("shirt_size"),
+    koozieType: ticketKoozieTypeEnum("koozie_type"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("ticket_order_passes_order_id_pass_number_unique").on(
+      table.orderId,
+      table.passNumber,
+    ),
+    index("ticket_order_passes_order_id_idx").on(table.orderId),
+    check(
+      "ticket_order_passes_pass_number_range",
+      sql`${table.passNumber} >= 1 and ${table.passNumber} <= ${sql.raw(
+        String(MAX_PASSES_PER_ORDER),
+      )}`,
+    ),
+    check(
+      "ticket_order_passes_amounts_nonnegative",
+      sql`${table.priceCents} >= 0 and ${table.nameYourPriceCents} >= 0`,
+    ),
+    check(
+      "ticket_order_passes_name_your_price_matches_package",
+      sql`(
+        ${table.packageId} = 'name-your-price' and
+        ${table.nameYourPriceCents} = ${table.priceCents}
+      ) or (
+        ${table.packageId} <> 'name-your-price' and
+        ${table.nameYourPriceCents} = 0
+      )`,
+    ),
+    check(
+      "ticket_order_passes_merch_matches_package",
+      sql`(
+        ${table.packageId} = 'ultimate' and
+        ${table.shirtStyle} is not null and
+        ${table.shirtColor} is not null and
+        ${table.shirtSize} is not null and
+        ${table.koozieType} is not null
+      ) or (
+        ${table.packageId} = 'koozie' and
+        ${table.shirtStyle} is null and
+        ${table.shirtColor} is null and
+        ${table.shirtSize} is null and
+        ${table.koozieType} is not null
+      ) or (
+        ${table.packageId} in ('sticker', 'name-your-price') and
+        ${table.shirtStyle} is null and
+        ${table.shirtColor} is null and
+        ${table.shirtSize} is null and
+        ${table.koozieType} is null
+      )`,
+    ),
+  ],
+);
+
 export type EventUpdateSignup = typeof eventUpdateSignups.$inferSelect;
 export type NewEventUpdateSignup = typeof eventUpdateSignups.$inferInsert;
+export type TicketOrder = typeof ticketOrders.$inferSelect;
+export type NewTicketOrder = typeof ticketOrders.$inferInsert;
+export type TicketOrderPass = typeof ticketOrderPasses.$inferSelect;
+export type NewTicketOrderPass = typeof ticketOrderPasses.$inferInsert;

--- a/lib/merch/catalog.ts
+++ b/lib/merch/catalog.ts
@@ -1,4 +1,25 @@
 import { z } from "zod";
+import {
+  KOOZIE_TYPE_VALUES,
+  PACKAGE_VALUES,
+  SHIRT_COLOR_VALUES,
+  SHIRT_SIZE_VALUES,
+  SHIRT_STYLE_VALUES,
+  type KoozieType,
+  type PackageId,
+  type ShirtColor,
+  type ShirtSize,
+  type ShirtStyle,
+} from "@/lib/tickets/constants";
+
+export {
+  KOOZIE_TYPE_VALUES,
+  PACKAGE_VALUES,
+  SHIRT_COLOR_VALUES,
+  SHIRT_SIZE_VALUES,
+  SHIRT_STYLE_VALUES,
+};
+export type { KoozieType, PackageId, ShirtColor, ShirtSize, ShirtStyle };
 
 export const MERCH_ASSETS = {
   lineup: "/merch/bubelpalooza-merch-lineup.png",
@@ -10,17 +31,6 @@ export const MERCH_ASSETS = {
   standardShortKoozie: "/merch/bubelpalooza-standard-short-koozie.jpg",
   sticker: "/merch/bubelpalooza-sticker.jpg",
 } as const;
-
-export const SHIRT_STYLE_VALUES = ["tee", "tank"] as const;
-export const SHIRT_COLOR_VALUES = ["black", "white"] as const;
-export const SHIRT_SIZE_VALUES = ["S", "M", "L", "XL", "2XL", "3XL"] as const;
-export const KOOZIE_TYPE_VALUES = ["slim-tall", "standard-short"] as const;
-export const PACKAGE_VALUES = [
-  "complete",
-  "koozie",
-  "sticker",
-  "name-your-price",
-] as const;
 
 export const shirtStyleSchema = z.enum(SHIRT_STYLE_VALUES);
 export const shirtColorSchema = z.enum(SHIRT_COLOR_VALUES);
@@ -38,11 +48,6 @@ export const koozieSelectionSchema = z.object({
   type: koozieTypeSchema,
 });
 
-export type ShirtStyle = z.infer<typeof shirtStyleSchema>;
-export type ShirtColor = z.infer<typeof shirtColorSchema>;
-export type ShirtSize = z.infer<typeof shirtSizeSchema>;
-export type KoozieType = z.infer<typeof koozieTypeSchema>;
-export type PackageId = z.infer<typeof packageSchema>;
 export type ShirtSelection = z.infer<typeof shirtSelectionSchema>;
 export type KoozieSelection = z.infer<typeof koozieSelectionSchema>;
 
@@ -108,7 +113,7 @@ export const koozieTypeOptions = [
 
 export const ticketPackages = [
   {
-    id: "complete",
+    id: "ultimate",
     name: "Ultimate package",
     shortName: "Ultimate",
     priceCents: 2500,

--- a/lib/tickets/cart.ts
+++ b/lib/tickets/cart.ts
@@ -19,9 +19,11 @@ import {
   type ShirtStyle,
   type TicketPackage,
 } from "@/lib/merch/catalog";
-
-export const MAX_PASSES_PER_ORDER = 6;
-export const TICKET_CART_STORAGE_KEY = "bubelpalooza-ticket-cart";
+import { MAX_PASSES_PER_ORDER } from "@/lib/tickets/constants";
+export {
+  MAX_PASSES_PER_ORDER,
+  TICKET_CART_STORAGE_KEY,
+} from "@/lib/tickets/constants";
 
 export const centsSchema = z
   .number()

--- a/lib/tickets/constants.ts
+++ b/lib/tickets/constants.ts
@@ -1,0 +1,19 @@
+export const MAX_PASSES_PER_ORDER = 6;
+export const TICKET_CART_STORAGE_KEY = "bubelpalooza-ticket-cart";
+
+export const SHIRT_STYLE_VALUES = ["tee", "tank"] as const;
+export const SHIRT_COLOR_VALUES = ["black", "white"] as const;
+export const SHIRT_SIZE_VALUES = ["S", "M", "L", "XL", "2XL", "3XL"] as const;
+export const KOOZIE_TYPE_VALUES = ["slim-tall", "standard-short"] as const;
+export const PACKAGE_VALUES = [
+  "ultimate",
+  "koozie",
+  "sticker",
+  "name-your-price",
+] as const;
+
+export type ShirtStyle = (typeof SHIRT_STYLE_VALUES)[number];
+export type ShirtColor = (typeof SHIRT_COLOR_VALUES)[number];
+export type ShirtSize = (typeof SHIRT_SIZE_VALUES)[number];
+export type KoozieType = (typeof KOOZIE_TYPE_VALUES)[number];
+export type PackageId = (typeof PACKAGE_VALUES)[number];

--- a/lib/tickets/orders.ts
+++ b/lib/tickets/orders.ts
@@ -1,0 +1,52 @@
+import {
+  getCartTotals,
+  getPassPriceCents,
+  ticketCartSchema,
+  type TicketCart,
+  type TicketCartInput,
+} from "@/lib/tickets/cart";
+import type {
+  KoozieSelection,
+  PackageId,
+  ShirtSelection,
+} from "@/lib/merch/catalog";
+
+export type TicketOrderPassSnapshot = {
+  passNumber: number;
+  packageId: PackageId;
+  priceCents: number;
+  nameYourPriceCents: number;
+  shirtSelection: ShirtSelection | null;
+  koozieSelection: KoozieSelection | null;
+};
+
+export type TicketOrderSnapshot = {
+  passes: TicketOrderPassSnapshot[];
+  passSubtotalCents: number;
+  donationCents: number;
+  totalCents: number;
+};
+
+export function createTicketOrderSnapshot(
+  cartInput: TicketCartInput | TicketCart,
+): TicketOrderSnapshot {
+  const cart = ticketCartSchema.parse(cartInput);
+  const totals = getCartTotals(cart);
+
+  return {
+    ...totals,
+    passes: cart.passes.map((pass, index) => {
+      const priceCents = getPassPriceCents(pass);
+
+      return {
+        passNumber: index + 1,
+        packageId: pass.packageId,
+        priceCents,
+        nameYourPriceCents:
+          pass.packageId === "name-your-price" ? priceCents : 0,
+        shirtSelection: pass.shirtSelection ?? null,
+        koozieSelection: pass.koozieSelection ?? null,
+      };
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- Add ticket order and pass tables with explicit package, payment, provider, shirt, and koozie enums
- Store pass-level package pricing, name-your-price pass contributions, order-level donations, and minimal customer/provider fields
- Add Drizzle migration and shared ticket constants/order snapshot helper for later checkout persistence

## Validation
- npm run db:generate
- npm run copy:check
- npm run lint
- npx tsc --noEmit
- npm run build

Closes #8