### PR TITLE
Persist ticket orders before Stripe checkout

### DIFF
--- a/app/api/tickets/checkout/route.ts
+++ b/app/api/tickets/checkout/route.ts
@@ -11,6 +11,12 @@ import {
   type TicketCartPass,
 } from "@/lib/tickets/cart";
 import { serverEnv } from "@/lib/env/server";
+import {
+  createCompletedNoPaymentTicketOrder,
+  createPendingStripeTicketOrder,
+  markTicketOrderCheckoutFailed,
+  updateTicketOrderStripeCheckoutSession,
+} from "@/lib/tickets/order-store";
 
 export const runtime = "nodejs";
 
@@ -132,17 +138,6 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!stripe) {
-    return NextResponse.json(
-      {
-        ok: false,
-        message:
-          "Checkout is not available right now. Please check back soon.",
-      },
-      { status: 503 },
-    );
-  }
-
   let body: unknown;
 
   try {
@@ -173,7 +168,47 @@ export async function POST(request: Request) {
   const cart = parsedCart.data;
   const totals = getCartTotals(cart);
 
+  if (totals.totalCents === 0) {
+    try {
+      await createCompletedNoPaymentTicketOrder(cart);
+
+      return NextResponse.json({
+        ok: true,
+        url: `${serverEnv.APP_URL}/tickets/success`,
+      });
+    } catch (error) {
+      console.error(
+        "Failed to create no-payment ticket order.",
+        error instanceof Error ? { name: error.name } : undefined,
+      );
+
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "Checkout is not available right now. Please try again soon.",
+        },
+        { status: 500 },
+      );
+    }
+  }
+
+  if (!stripe) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message:
+          "Checkout is not available right now. Please check back soon.",
+      },
+      { status: 503 },
+    );
+  }
+
+  let pendingOrder: Awaited<ReturnType<typeof createPendingStripeTicketOrder>> | null =
+    null;
+
   try {
+    pendingOrder = await createPendingStripeTicketOrder(cart);
+
     const checkoutSession = await stripe.checkout.sessions.create({
       mode: "payment",
       branding_settings: getCheckoutBrandingSettings(),
@@ -186,18 +221,24 @@ export async function POST(request: Request) {
       line_items: createCheckoutLineItems(cart),
       success_url: `${serverEnv.APP_URL}/tickets/success`,
       cancel_url: `${serverEnv.APP_URL}/tickets`,
-      client_reference_id: crypto.randomUUID(),
+      client_reference_id: pendingOrder.id,
       metadata: {
         source: "tickets_wizard",
-        pass_count: String(cart.passes.length),
-        donation_cents: String(cart.donationCents),
-        total_cents: String(totals.totalCents),
+        order_id: pendingOrder.id,
       },
     });
 
     if (!checkoutSession.url) {
       throw new Error("Stripe Checkout session did not return a URL.");
     }
+
+    await updateTicketOrderStripeCheckoutSession({
+      orderId: pendingOrder.id,
+      stripeCheckoutSessionId: checkoutSession.id,
+      stripeCheckoutStatus: checkoutSession.status,
+      stripePaymentStatus: checkoutSession.payment_status,
+      stripeClientReferenceId: checkoutSession.client_reference_id,
+    });
 
     return NextResponse.json({
       ok: true,
@@ -208,6 +249,17 @@ export async function POST(request: Request) {
       "Failed to create package Checkout session.",
       error instanceof Error ? { name: error.name } : undefined,
     );
+
+    if (pendingOrder) {
+      try {
+        await markTicketOrderCheckoutFailed(pendingOrder.id);
+      } catch (updateError) {
+        console.error(
+          "Failed to mark package Checkout order as failed.",
+          updateError instanceof Error ? { name: updateError.name } : undefined,
+        );
+      }
+    }
 
     return NextResponse.json(
       {

--- a/lib/tickets/order-store.ts
+++ b/lib/tickets/order-store.ts
@@ -1,0 +1,137 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import { ticketOrderPasses, ticketOrders } from "@/lib/db/schema";
+import type { TicketCart } from "@/lib/tickets/cart";
+import { createTicketOrderSnapshot } from "@/lib/tickets/orders";
+
+type PersistedTicketOrder = {
+  id: string;
+  passCount: number;
+  passSubtotalCents: number;
+  donationCents: number;
+  totalCents: number;
+};
+
+type CreateTicketOrderOptions = {
+  cart: TicketCart;
+  paymentProvider: "stripe" | "none";
+  status: "pending" | "completed";
+  paymentStatus: "unpaid" | "no_payment_required";
+  completedAt?: Date;
+};
+
+type StripeCheckoutSessionUpdate = {
+  orderId: string;
+  stripeCheckoutSessionId: string;
+  stripeCheckoutStatus: string | null;
+  stripePaymentStatus: string | null;
+  stripeClientReferenceId: string | null;
+};
+
+function createTicketOrderPassRows(
+  orderId: string,
+  snapshot: ReturnType<typeof createTicketOrderSnapshot>,
+) {
+  return snapshot.passes.map((pass) => ({
+    orderId,
+    passNumber: pass.passNumber,
+    packageId: pass.packageId,
+    priceCents: pass.priceCents,
+    nameYourPriceCents: pass.nameYourPriceCents,
+    shirtStyle: pass.shirtSelection?.style ?? null,
+    shirtColor: pass.shirtSelection?.color ?? null,
+    shirtSize: pass.shirtSelection?.size ?? null,
+    koozieType: pass.koozieSelection?.type ?? null,
+  }));
+}
+
+async function createTicketOrder({
+  cart,
+  paymentProvider,
+  status,
+  paymentStatus,
+  completedAt,
+}: CreateTicketOrderOptions): Promise<PersistedTicketOrder> {
+  const db = getDb();
+  const orderId = crypto.randomUUID();
+  const snapshot = createTicketOrderSnapshot(cart);
+  const passRows = createTicketOrderPassRows(orderId, snapshot);
+
+  await db.batch([
+    db.insert(ticketOrders).values({
+      id: orderId,
+      status,
+      paymentStatus,
+      paymentProvider,
+      currency: "usd",
+      passCount: snapshot.passes.length,
+      passSubtotalCents: snapshot.passSubtotalCents,
+      donationCents: snapshot.donationCents,
+      totalCents: snapshot.totalCents,
+      stripeClientReferenceId: paymentProvider === "stripe" ? orderId : null,
+      completedAt,
+    }),
+    db.insert(ticketOrderPasses).values(passRows),
+  ]);
+
+  return {
+    id: orderId,
+    passCount: snapshot.passes.length,
+    passSubtotalCents: snapshot.passSubtotalCents,
+    donationCents: snapshot.donationCents,
+    totalCents: snapshot.totalCents,
+  };
+}
+
+export function createPendingStripeTicketOrder(cart: TicketCart) {
+  return createTicketOrder({
+    cart,
+    paymentProvider: "stripe",
+    status: "pending",
+    paymentStatus: "unpaid",
+  });
+}
+
+export function createCompletedNoPaymentTicketOrder(cart: TicketCart) {
+  return createTicketOrder({
+    cart,
+    paymentProvider: "none",
+    status: "completed",
+    paymentStatus: "no_payment_required",
+    completedAt: new Date(),
+  });
+}
+
+export async function updateTicketOrderStripeCheckoutSession({
+  orderId,
+  stripeCheckoutSessionId,
+  stripeCheckoutStatus,
+  stripePaymentStatus,
+  stripeClientReferenceId,
+}: StripeCheckoutSessionUpdate) {
+  const db = getDb();
+
+  await db
+    .update(ticketOrders)
+    .set({
+      stripeCheckoutSessionId,
+      stripeCheckoutStatus,
+      stripePaymentStatus,
+      stripeClientReferenceId,
+      updatedAt: new Date(),
+    })
+    .where(eq(ticketOrders.id, orderId));
+}
+
+export async function markTicketOrderCheckoutFailed(orderId: string) {
+  const db = getDb();
+
+  await db
+    .update(ticketOrders)
+    .set({
+      status: "failed",
+      paymentStatus: "failed",
+      updatedAt: new Date(),
+    })
+    .where(eq(ticketOrders.id, orderId));
+}


### PR DESCRIPTION
## Summary
- Create persisted pending ticket orders and pass rows before paid Stripe Checkout sessions
- Use the internal order id as Stripe client_reference_id and metadata, instead of storing cart details in metadata
- Persist zero-dollar carts as no-payment-required completed orders and send guests to the success page without Stripe
- Mark pending orders failed if Checkout session creation fails before redirect

## Validation
- npm run db:generate
- npm run copy:check
- npm run lint
- npx tsc --noEmit
- npm run build

## Notes
- Production checkout remains gated by NEXT_PUBLIC_TICKETS_CHECKOUT_ENABLED.
- Verified webhook completion remains in #10.
- I did not run a live Stripe Checkout session locally.

Closes #9